### PR TITLE
Make setup clearer and keep Digest visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-Understand a YouTube video before deciding how much of it to watch. YouTube Digest opens beside YouTube in Chrome and helps you:
+Turn every YouTube video into a resource for deep learning. YouTube Digest brings transcripts, bilingual translation, AI overviews, explanations, and timestamped notes into one Chrome side panel, so you can study ideas and language without losing your place.
 
-- Decide what is worth watching with an AI overview, chapters, and key quotes.
+- Turn captions into a readable, searchable learning resource.
+- Learn languages with the original transcript, a Simplified Chinese translation, or an aligned bilingual view.
+- Build understanding with an AI overview, chapters, key quotes, and selected-text explanations.
 - Navigate long videos by clicking timestamps in the transcript, overview, or notes.
-- Learn with the original transcript, a Simplified Chinese translation, or an aligned bilingual view.
-- Explain selected text and clean up fragmented captions into readable thoughts.
-- Save timestamped notes and return to the relevant moment later.
+- Clean up fragmented captions and save timestamped notes for later study.
 - Keep control of your data with your own API keys, local Chrome storage, and no analytics or telemetry.
 
 YouTube Digest is a bring-your-own-key project installed locally from GitHub. It is not available through the Chrome Web Store, does not include API credits, and does not run a developer-operated server.
@@ -22,7 +22,7 @@ You do not need to understand the code or use the command line. Send this messag
 Your agent should:
 
 1. Download or clone the repository to a folder you plan to keep.
-2. Help you create your own Supadata and AI provider accounts.
+2. Open the official Supadata and DeepSeek pages below and help you create your own accounts.
 3. Walk you through loading the folder in Chrome with **Load unpacked**.
 4. Show you where to enter your API keys in the extension's **Settings** page.
 5. Open a YouTube video with captions and confirm the transcript and translation work.
@@ -51,7 +51,28 @@ YouTube Digest needs two keys under your own provider accounts:
 1. A **Supadata API key** to retrieve YouTube transcripts.
 2. An **AI provider API key** for overviews, cleanup, explanations, and translation.
 
-Open **Settings** from the side panel. You can also open the YouTube Digest **Options** page from its card at `chrome://extensions` or by right-clicking its toolbar icon.
+### Get a Supadata API key
+
+1. Open the official [Supadata sign-up page](https://dash.supadata.ai/auth/sign-up).
+2. Create an account and complete the short onboarding flow.
+3. Supadata generates an API key automatically during onboarding.
+4. Open the [Supadata dashboard](https://dash.supadata.ai/) whenever you need to find or manage the key.
+5. Copy the key and paste it into **Supadata API key** in YouTube Digest Settings.
+
+See the [official Supadata documentation](https://docs.supadata.ai/) if the dashboard flow changes.
+
+### Get a DeepSeek API key
+
+1. Open the official [DeepSeek API Keys page](https://platform.deepseek.com/api_keys).
+2. Sign in or create a DeepSeek Platform account when prompted.
+3. Choose **Create new API key**, give it a recognizable name such as `YouTube Digest`, and create it.
+4. Copy the key immediately. The full key may only be shown once.
+5. Paste it into **AI API key** in YouTube Digest Settings.
+6. If DeepSeek reports insufficient balance, add credit in your DeepSeek Platform account and try again.
+
+See the [official DeepSeek API documentation](https://api-docs.deepseek.com/) for current account and API details.
+
+Open **Settings** from the side panel. You can also open the YouTube Digest **Options** page from its card at `chrome://extensions` or by right-clicking its toolbar icon. Paste keys only into these Settings fields. Never paste a key into an AI chat, repository file, screenshot, or public message.
 
 The default AI provider is DeepSeek:
 
@@ -128,6 +149,14 @@ YouTube Digest makes provider requests directly from the extension:
 There is no YouTube Digest account system, advertising, analytics, or telemetry. Supadata and the AI provider still receive data under their own terms and privacy policies. See [PRIVACY.md](PRIVACY.md) for details.
 
 ## Troubleshooting
+
+### The Digest button is missing on a YouTube video
+
+- At `chrome://extensions`, find YouTube Digest and click **Reload**, then refresh the YouTube tab.
+- Confirm that you are on a standard `https://www.youtube.com/watch?...` page, not a Short, embed, or live page.
+- The current version automatically follows YouTube when its responsive action bar changes. Wait a moment after the page finishes loading.
+- If you have an older downloaded copy, resizing the YouTube window horizontally once may reveal the button. Then download the latest version so resizing is no longer required.
+- If it is still missing, ask your coding agent to inspect the content script on that exact video page.
 
 ### The side panel does not open
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,13 +2,13 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-在决定要不要完整观看一个 YouTube 视频之前，先快速了解它。YouTube Digest 会显示在 Chrome 的 YouTube 侧边栏中，可以帮助你：
+把每个 YouTube 视频变成一份可以深入学习的资料。YouTube Digest 把字幕、双语翻译、AI 概览、内容讲解和时间戳笔记放进同一个 Chrome 侧边栏，让你可以持续学习视频中的知识和语言，同时不丢失原视频上下文。
 
-- 通过 AI 概览、章节和重点引用判断视频是否值得看。
+- 把零碎字幕变成清晰、可搜索的学习资料。
+- 查看原文、简体中文翻译，或中英双语对照字幕来学习语言。
+- 通过 AI 概览、章节、重点引用和选中文本讲解建立系统理解。
 - 点击字幕、概览或笔记中的时间戳，快速跳转到对应位置。
-- 查看原文、简体中文翻译，或中英双语对照字幕。
-- 选中字幕内容进行讲解，并把零碎字幕整理成更容易阅读的句子。
-- 保存带时间戳的笔记，之后可以回到视频中的对应位置。
+- 整理零碎字幕并保存带时间戳的笔记，方便之后复习。
 - 使用自己的 API Key，数据保存在本地 Chrome 中，不包含分析统计或行为追踪。
 
 YouTube Digest 是一个需要自行提供 API Key 的开源项目，通过 GitHub 安装。目前没有上架 Chrome 应用商店，不赠送 API 额度，也没有开发者运营的服务器。
@@ -22,7 +22,7 @@ YouTube Digest 是一个需要自行提供 API Key 的开源项目，通过 GitH
 你的 Agent 应该帮你：
 
 1. 下载或克隆项目，并保存到一个不会随意删除的文件夹。
-2. 指导你创建自己的 Supadata 和 AI 服务账号。
+2. 打开下方 Supadata 和 DeepSeek 官方页面，指导你创建自己的账号。
 3. 指导你在 Chrome 中通过“加载已解压的扩展程序”安装项目。
 4. 告诉你应该在扩展的“设置”页面哪个位置填写 API Key。
 5. 打开一个带字幕的 YouTube 视频，确认字幕和翻译功能可以使用。
@@ -51,7 +51,28 @@ YouTube Digest 需要你在自己的服务账号中准备两个 Key：
 1. **Supadata API Key**，用于获取 YouTube 字幕。
 2. **AI 服务 API Key**，用于生成概览、整理字幕、讲解内容和翻译。
 
-在侧边栏中打开 **Settings**。你也可以在 `chrome://extensions` 的 YouTube Digest 卡片中打开扩展选项。
+### 获取 Supadata API Key
+
+1. 打开 Supadata 官方[注册页面](https://dash.supadata.ai/auth/sign-up)。
+2. 创建账号并完成简短的新手引导。
+3. Supadata 会在新手引导过程中自动生成 API Key。
+4. 之后可以随时打开 [Supadata 控制台](https://dash.supadata.ai/)查找或管理 Key。
+5. 复制 Key，并粘贴到 YouTube Digest 设置中的 **Supadata API key**。
+
+如果页面流程发生变化，请查看 [Supadata 官方文档](https://docs.supadata.ai/)。
+
+### 获取 DeepSeek API Key
+
+1. 打开 DeepSeek 官方 [API Keys 页面](https://platform.deepseek.com/api_keys)。
+2. 按照提示登录，或创建 DeepSeek 开放平台账号。
+3. 点击 **Create new API key**，填写容易识别的名称，例如 `YouTube Digest`，然后创建 Key。
+4. 立即复制 Key。完整 Key 可能只会显示一次。
+5. 把 Key 粘贴到 YouTube Digest 设置中的 **AI API key**。
+6. 如果 DeepSeek 提示余额不足，请在 DeepSeek 开放平台账号中充值后再试。
+
+当前账号和接口说明请查看 [DeepSeek 官方 API 文档](https://api-docs.deepseek.com/)。
+
+在侧边栏中打开 **Settings**。你也可以在 `chrome://extensions` 的 YouTube Digest 卡片中打开扩展选项。Key 只能粘贴到这些设置输入框中。不要把 Key 发送到 AI 对话、项目文件、截图或公开消息中。
 
 默认 AI 服务是 DeepSeek：
 
@@ -128,6 +149,14 @@ YouTube Digest 会直接从扩展向服务商发送请求：
 YouTube Digest 没有账号系统、广告、分析统计或行为追踪。Supadata 和 AI 服务仍会按照各自的条款和隐私政策处理数据。详情请查看 [PRIVACY.md](PRIVACY.md)。
 
 ## 常见问题
+
+### YouTube 视频页面没有显示 Digest 按钮
+
+- 在 `chrome://extensions` 中找到 YouTube Digest，点击“重新加载”，然后刷新 YouTube 页面。
+- 确认当前页面是标准 `https://www.youtube.com/watch?...` 页面，而不是 Shorts、嵌入页面或直播页面。
+- 当前版本会在 YouTube 响应式操作栏变化时自动重新定位按钮。页面加载完成后可以稍等片刻。
+- 如果你使用的是较早下载的版本，可以先横向调整一次 YouTube 窗口宽度让按钮出现，然后下载最新版，这样之后不再需要调整窗口。
+- 如果按钮仍然没有出现，让你的编程 Agent 在这个具体视频页面检查 content script。
 
 ### 侧边栏无法打开
 

--- a/content.js
+++ b/content.js
@@ -26,6 +26,10 @@ let ytdNoteButton = null;
 let ytdNoteButtonTimer = null;
 let ytdNoteKeyboardListenerAdded = false;
 let ytdNoteButtonRetryTimer = null;
+let ytdDigestButton = null;
+let digestButtonObserver = null;
+let digestButtonReconcileTimer = null;
+let digestButtonResizeListenerAdded = false;
 
 // ============================================================
 // INITIALIZATION
@@ -49,6 +53,7 @@ function init() {
   // Also set up an observer to handle YouTube's dynamic content loading
   // (YouTube is an SPA, so elements appear/disappear as you navigate)
   setupButtonObserver();
+  setupDigestButtonResizeListener();
 }
 
 /**
@@ -174,46 +179,52 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
  *
  * When clicked, it opens the YouTube Digest side panel.
  */
-function injectDigestButton() {
-  // Don't inject if we're not on a video page
-  if (!window.location.pathname.includes("/watch")) return;
+function isVisibleDigestHost(element) {
+  if (!element || !element.isConnected) return false;
 
-  // Don't inject if button already exists
-  if (document.getElementById("ytd-digest-button")) return;
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return false;
 
-  // Find YouTube's action buttons container (where Share, Save, etc. live)
-  // IMPORTANT: We must scope this to the PRIMARY video metadata only.
-  // YouTube reuses #top-level-buttons-computed in playlists, comments, etc.
-  // The video's action bar lives inside ytd-watch-metadata or #actions
-  // within the primary column (#primary / #columns #primary).
-  const actionsContainer = document.querySelector(
-    "ytd-watch-metadata #actions #top-level-buttons-computed, " +
-      "ytd-watch-metadata #top-level-buttons-computed, " +
-      "#primary #actions #top-level-buttons-computed, " +
-      "#actions #top-level-buttons-computed, " +
-      "#top-level-buttons-computed",
+  const style = window.getComputedStyle(element);
+  return style.display !== "none" && style.visibility !== "hidden";
+}
+
+/**
+ * YouTube keeps hidden copies of its responsive action toolbar in the DOM.
+ * querySelector() can return one of those 0x0 copies before the toolbar the
+ * viewer can actually see, so inspect every candidate and prefer the visible
+ * #actions-inner that belongs to the current video's metadata.
+ */
+function findDigestButtonHost() {
+  const primaryActionRows = Array.from(
+    document.querySelectorAll("ytd-watch-metadata #actions-inner"),
+  );
+  const visibleActionRow = primaryActionRows.find(isVisibleDigestHost);
+  if (visibleActionRow) return visibleActionRow;
+
+  const fallbackCandidates = Array.from(
+    document.querySelectorAll(
+      "ytd-watch-metadata #actions #top-level-buttons-computed, " +
+        "ytd-watch-metadata #top-level-buttons-computed, " +
+        "#primary #actions #top-level-buttons-computed",
+    ),
   );
 
-  if (!actionsContainer) {
-    // Container not found yet — will retry via observer
-    debugLog("[YouTube Digest Content] Actions container not found yet");
-    return;
-  }
+  return (
+    fallbackCandidates.find(
+      (candidate) =>
+        isVisibleDigestHost(candidate) &&
+        (candidate.closest("ytd-watch-metadata") ||
+          candidate.closest("#primary")),
+    ) || null
+  );
+}
 
-  // Avoid injecting into the wrong container (e.g. playlist/comment menus)
-  const isInPrimary =
-    actionsContainer.closest("#primary") ||
-    actionsContainer.closest("ytd-watch-metadata");
-  if (!isInPrimary) {
-    debugLog("[YouTube Digest Content] Actions container not in primary column");
-    return;
-  }
-
-  debugLog("[YouTube Digest Content] Injecting Digest button");
-
-  // Create our Digest button
+function createDigestButton() {
   const digestButton = document.createElement("button");
   digestButton.id = "ytd-digest-button";
+  digestButton.type = "button";
+  digestButton.setAttribute("aria-label", "Open YouTube Digest");
   digestButton.innerHTML = `
     <span class="ytd-digest-icon" style="font-size: 11px;">▶</span>
     <span class="ytd-digest-label">Digest</span>
@@ -270,9 +281,80 @@ function injectDigestButton() {
     }
   });
 
-  // Insert the button at the end of the actions container
-  actionsContainer.appendChild(digestButton);
-  debugLog("[YouTube Digest Content] Digest button injected");
+  ytdDigestButton = digestButton;
+  return digestButton;
+}
+
+/**
+ * Reconciles the Digest button with YouTube's currently visible action row.
+ * This is intentionally idempotent because YouTube rebuilds its watch page
+ * during navigation and at responsive breakpoints.
+ */
+function injectDigestButton() {
+  const existingButtons = Array.from(
+    document.querySelectorAll("#ytd-digest-button"),
+  );
+
+  if (!window.location.pathname.includes("/watch")) {
+    existingButtons.forEach((button) => button.remove());
+    ytdDigestButton = null;
+    return false;
+  }
+
+  const actionsContainer = findDigestButtonHost();
+  if (!actionsContainer) {
+    debugLog("[YouTube Digest Content] Visible actions container not found yet");
+    return false;
+  }
+
+  let digestButton = existingButtons.find(
+    (button) => button === ytdDigestButton,
+  );
+
+  if (!digestButton) {
+    existingButtons.forEach((button) => button.remove());
+    existingButtons.length = 0;
+    digestButton = createDigestButton();
+  }
+
+  existingButtons.forEach((button) => {
+    if (button !== digestButton) button.remove();
+  });
+
+  if (digestButton.parentElement !== actionsContainer) {
+    // #actions-inner is outside YouTube's horizontally shrinkable native
+    // button list. Keeping Digest as its own sibling prevents it from being
+    // clipped when the watch page gets narrow. The fallback host uses prepend
+    // so Digest receives visibility priority on older YouTube layouts.
+    if (actionsContainer.id === "actions-inner") {
+      actionsContainer.appendChild(digestButton);
+    } else {
+      actionsContainer.insertBefore(digestButton, actionsContainer.firstChild);
+    }
+  }
+
+  debugLog("[YouTube Digest Content] Digest button reconciled");
+  return true;
+}
+
+function scheduleDigestButtonReconciliation(delay = 80) {
+  if (digestButtonReconcileTimer) {
+    clearTimeout(digestButtonReconcileTimer);
+  }
+
+  digestButtonReconcileTimer = setTimeout(() => {
+    digestButtonReconcileTimer = null;
+    injectDigestButton();
+  }, delay);
+}
+
+function setupDigestButtonResizeListener() {
+  if (digestButtonResizeListenerAdded) return;
+
+  window.addEventListener("resize", () => {
+    scheduleDigestButtonReconciliation(120);
+  });
+  digestButtonResizeListenerAdded = true;
 }
 
 /**
@@ -280,12 +362,12 @@ function injectDigestButton() {
  * When the action buttons container appears (after navigation), we inject our button.
  */
 function setupButtonObserver() {
-  const observer = new MutationObserver((mutations) => {
+  if (digestButtonObserver) return;
+
+  digestButtonObserver = new MutationObserver(() => {
     // Check if we need to inject the buttons
     if (window.location.pathname.includes("/watch")) {
-      if (!document.getElementById("ytd-digest-button")) {
-        injectDigestButton();
-      }
+      scheduleDigestButtonReconciliation();
       if (!ytdNoteButton || !ytdNoteButton.isConnected) {
         tryInjectNoteButton();
       }
@@ -293,7 +375,7 @@ function setupButtonObserver() {
   });
 
   // Watch the entire body for changes (YouTube rebuilds large chunks of the DOM)
-  observer.observe(document.body, {
+  digestButtonObserver.observe(document.body, {
     childList: true,
     subtree: true,
   });
@@ -720,8 +802,14 @@ document.addEventListener("yt-navigate-finish", () => {
   existingMarkers.forEach((m) => m.remove());
 
   // Remove old buttons (they will be re-injected for the new video)
-  const existingDigestButton = document.getElementById("ytd-digest-button");
-  if (existingDigestButton) existingDigestButton.remove();
+  document
+    .querySelectorAll("#ytd-digest-button")
+    .forEach((button) => button.remove());
+  ytdDigestButton = null;
+  if (digestButtonReconcileTimer) {
+    clearTimeout(digestButtonReconcileTimer);
+    digestButtonReconcileTimer = null;
+  }
 
   const existingNoteButton = document.getElementById("ytd-note-button");
   if (existingNoteButton) existingNoteButton.remove();
@@ -741,7 +829,7 @@ document.addEventListener("yt-navigate-finish", () => {
 
   // Re-inject buttons for the new video (with a small delay for YouTube to render)
   setTimeout(() => {
-    injectDigestButton();
+    scheduleDigestButtonReconciliation(0);
     tryInjectNoteButton();
   }, 500);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "YouTube Digest",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minimum_chrome_version": "116",
-  "description": "Read and translate YouTube videos with timestamped transcripts, AI overviews, and notes.",
+  "description": "Turn YouTube videos into learning resources with transcripts, bilingual translation, AI overviews, and notes.",
   "permissions": ["sidePanel", "storage", "tabs", "scripting"],
   "host_permissions": [
     "https://www.youtube.com/*",

--- a/options.html
+++ b/options.html
@@ -32,9 +32,12 @@
           />
           <p class="help">
             Used to fetch timestamped YouTube subtitles.
-            <a href="https://supadata.ai/" target="_blank" rel="noreferrer"
-              >Get a Supadata key</a
-            >.
+            <a
+              href="https://dash.supadata.ai/auth/sign-up"
+              target="_blank"
+              rel="noreferrer"
+              >Create a Supadata account and key</a
+            >. Supadata generates the key during onboarding.
           </p>
         </section>
 
@@ -81,6 +84,12 @@
           <p class="help" id="providerHelp">
             DeepSeek uses <code>https://api.deepseek.com</code> and
             <code>deepseek-v4-flash</code>.
+            <a
+              href="https://platform.deepseek.com/api_keys"
+              target="_blank"
+              rel="noreferrer"
+              >Create a DeepSeek API key</a
+            >.
           </p>
           <div class="privacy-note">
             When you use AI features, the selected provider receives the video

--- a/options.js
+++ b/options.js
@@ -40,7 +40,7 @@ function updateProviderFields() {
     aiBaseUrlInput.value = YTD_SETTINGS.DEFAULTS.aiBaseUrl;
     aiModelInput.value = YTD_SETTINGS.DEFAULTS.aiModel;
     providerHelp.innerHTML =
-      'DeepSeek uses <code>https://api.deepseek.com</code> and <code>deepseek-v4-flash</code>.';
+      'DeepSeek uses <code>https://api.deepseek.com</code> and <code>deepseek-v4-flash</code>. <a href="https://platform.deepseek.com/api_keys" target="_blank" rel="noreferrer">Create a DeepSeek API key</a>.';
   } else {
     providerHelp.textContent =
       "Enter an OpenAI-compatible base URL and model identifier. HTTPS is required except for localhost.";

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "youtube-digest",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
-  "description": "Bring-your-own-key Chrome extension for YouTube transcripts, AI overviews, translation, and notes.",
+  "description": "Turn YouTube videos into learning resources with transcripts, bilingual translation, AI overviews, and notes.",
   "license": "MIT",
   "scripts": {
     "test": "node --test tests/*.test.js",

--- a/tests/digest-button.test.js
+++ b/tests/digest-button.test.js
@@ -1,0 +1,306 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const contentScript = fs.readFileSync(
+  path.resolve(__dirname, "..", "content.js"),
+  "utf8",
+);
+
+class FakeElement {
+  constructor({
+    id = "",
+    width = 100,
+    height = 36,
+    inMetadata = false,
+    inPrimary = false,
+  } = {}) {
+    this.id = id;
+    this.width = width;
+    this.height = height;
+    this.inMetadata = inMetadata;
+    this.inPrimary = inPrimary;
+    this.isConnected = true;
+    this.parentElement = null;
+    this.children = [];
+    this.style = {};
+    this.listeners = {};
+  }
+
+  get firstChild() {
+    return this.children[0] || null;
+  }
+
+  getBoundingClientRect() {
+    return { width: this.width, height: this.height };
+  }
+
+  closest(selector) {
+    if (selector === "ytd-watch-metadata" && this.inMetadata) return this;
+    if (selector === "#primary" && this.inPrimary) return this;
+    return null;
+  }
+
+  addEventListener(type, listener) {
+    this.listeners[type] = listener;
+  }
+
+  setAttribute(name, value) {
+    this[name] = value;
+  }
+
+  appendChild(child) {
+    child.parentElement?.removeChild(child);
+    this.children.push(child);
+    child.parentElement = this;
+    child.isConnected = true;
+    return child;
+  }
+
+  insertBefore(child, before) {
+    child.parentElement?.removeChild(child);
+    const index = before ? this.children.indexOf(before) : -1;
+    if (index >= 0) this.children.splice(index, 0, child);
+    else this.children.push(child);
+    child.parentElement = this;
+    child.isConnected = true;
+    return child;
+  }
+
+  removeChild(child) {
+    this.children = this.children.filter((candidate) => candidate !== child);
+    child.parentElement = null;
+  }
+
+  remove() {
+    this.parentElement?.removeChild(this);
+    this.isConnected = false;
+  }
+}
+
+function createHarness() {
+  const actionRows = [];
+  const fallbackRows = [];
+  const elements = [];
+  const documentListeners = {};
+  const windowListeners = {};
+  const observers = [];
+  const timers = new Map();
+  let nextTimerId = 1;
+
+  const document = {
+    readyState: "loading",
+    body: new FakeElement(),
+    addEventListener(type, listener) {
+      documentListeners[type] = listener;
+    },
+    querySelectorAll(selector) {
+      if (selector === "ytd-watch-metadata #actions-inner") return actionRows;
+      if (selector === "#ytd-digest-button") {
+        return elements.filter(
+          (element) => element.id === "ytd-digest-button" && element.isConnected,
+        );
+      }
+      if (selector.includes("top-level-buttons-computed")) return fallbackRows;
+      return [];
+    },
+    querySelector() {
+      return null;
+    },
+    getElementById(id) {
+      return elements.find((element) => element.id === id && element.isConnected);
+    },
+    createElement() {
+      const element = new FakeElement();
+      elements.push(element);
+      return element;
+    },
+  };
+
+  const context = vm.createContext({
+    console,
+    document,
+    window: {
+      location: { pathname: "/watch" },
+      addEventListener(type, listener) {
+        windowListeners[type] = listener;
+      },
+      getComputedStyle(element) {
+        return {
+          display: element.display || "flex",
+          visibility: element.visibility || "visible",
+        };
+      },
+    },
+    chrome: {
+      runtime: {
+        onMessage: { addListener() {} },
+        async sendMessage() {
+          return { success: true };
+        },
+      },
+    },
+    MutationObserver: class {
+      constructor(callback) {
+        this.callback = callback;
+        observers.push(this);
+      }
+      observe() {}
+    },
+    setTimeout(callback) {
+      const id = nextTimerId++;
+      timers.set(id, callback);
+      return id;
+    },
+    clearTimeout(id) {
+      timers.delete(id);
+    },
+    setInterval() {
+      return nextTimerId++;
+    },
+    clearInterval() {},
+  });
+
+  vm.runInContext(contentScript, context);
+
+  return {
+    context,
+    actionRows,
+    fallbackRows,
+    elements,
+    documentListeners,
+    windowListeners,
+    observers,
+    flushTimers() {
+      const callbacks = Array.from(timers.values());
+      timers.clear();
+      callbacks.forEach((callback) => callback());
+    },
+  };
+}
+
+test("Digest button skips a hidden responsive toolbar", () => {
+  const harness = createHarness();
+  const hiddenRow = new FakeElement({
+    id: "actions-inner",
+    width: 0,
+    height: 0,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  const visibleRow = new FakeElement({
+    id: "actions-inner",
+    width: 389,
+    height: 36,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  harness.actionRows.push(hiddenRow, visibleRow);
+
+  assert.equal(harness.context.findDigestButtonHost(), visibleRow);
+  assert.equal(harness.context.injectDigestButton(), true);
+  assert.equal(hiddenRow.children.length, 0);
+  assert.equal(visibleRow.children[0].id, "ytd-digest-button");
+});
+
+test("Digest button replaces stale instances and removes duplicates", () => {
+  const harness = createHarness();
+  const staleRow = new FakeElement({
+    id: "actions-inner",
+    width: 0,
+    height: 0,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  const visibleRow = new FakeElement({
+    id: "actions-inner",
+    width: 500,
+    height: 36,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  harness.actionRows.push(staleRow, visibleRow);
+
+  const staleButton = new FakeElement();
+  staleButton.id = "ytd-digest-button";
+  const duplicateButton = new FakeElement();
+  duplicateButton.id = "ytd-digest-button";
+  harness.elements.push(staleButton, duplicateButton);
+  staleRow.appendChild(staleButton);
+  staleRow.appendChild(duplicateButton);
+
+  assert.equal(harness.context.injectDigestButton(), true);
+  assert.equal(staleRow.children.length, 0);
+  assert.equal(visibleRow.children.length, 1);
+  assert.notEqual(visibleRow.children[0], staleButton);
+  assert.equal(visibleRow.children[0].id, "ytd-digest-button");
+  assert.equal(staleButton.isConnected, false);
+  assert.equal(duplicateButton.isConnected, false);
+});
+
+test("resize reconciliation follows YouTube to the newly visible toolbar", () => {
+  const harness = createHarness();
+  const firstRow = new FakeElement({
+    id: "actions-inner",
+    width: 500,
+    height: 36,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  const secondRow = new FakeElement({
+    id: "actions-inner",
+    width: 0,
+    height: 0,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  harness.actionRows.push(firstRow, secondRow);
+
+  harness.context.injectDigestButton();
+  harness.context.setupDigestButtonResizeListener();
+  firstRow.width = 0;
+  firstRow.height = 0;
+  secondRow.width = 389;
+  secondRow.height = 36;
+
+  harness.windowListeners.resize();
+  harness.flushTimers();
+
+  assert.equal(firstRow.children.length, 0);
+  assert.equal(secondRow.children.length, 1);
+  assert.equal(secondRow.children[0].id, "ytd-digest-button");
+});
+
+test("DOM mutation reconciliation repairs a replaced toolbar", () => {
+  const harness = createHarness();
+  const oldRow = new FakeElement({
+    id: "actions-inner",
+    width: 500,
+    height: 36,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  const newRow = new FakeElement({
+    id: "actions-inner",
+    width: 0,
+    height: 0,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  harness.actionRows.push(oldRow, newRow);
+
+  harness.context.injectDigestButton();
+  harness.context.setupButtonObserver();
+  oldRow.width = 0;
+  oldRow.height = 0;
+  newRow.width = 500;
+  newRow.height = 36;
+
+  harness.observers[0].callback([]);
+  harness.flushTimers();
+
+  assert.equal(oldRow.children.length, 0);
+  assert.equal(newRow.children.length, 1);
+});

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -38,6 +38,11 @@ test("release copy documents current scope without em dashes", () => {
     /\bYT Digest\b/,
   );
   assert.match(readme, /^# YouTube Digest$/m);
+  assert.match(
+    readme,
+    /Turn every YouTube video into a resource for deep learning\./,
+  );
+  assert.doesNotMatch(readme, /before deciding how much of it to watch/i);
   assert.match(readme, /^## Install with your coding agent$/m);
   assert.match(
     readme,
@@ -46,6 +51,7 @@ test("release copy documents current scope without em dashes", () => {
   assert.match(readme, /upstream issues and pull requests are not accepted/i);
   assert.doesNotMatch(readme, /^## Contributing$/m);
   assert.match(chineseReadme, /^# YouTube Digest$/m);
+  assert.match(chineseReadme, /把每个 YouTube 视频变成一份可以深入学习的资料/);
   assert.match(chineseReadme, /^## 让你的编程 Agent 帮你安装$/m);
   assert.match(chineseReadme, /不接受上游 Issue 或 Pull Request/);
   assert.match(chineseReadme, /增加更多翻译语言/);
@@ -58,6 +64,22 @@ test("release copy documents current scope without em dashes", () => {
   assert.match(readme, /roughly 100 transcript lookups per month/i);
   assert.match(readme, /supadata\.ai\/pricing/i);
   assert.match(readme, /docs\.supadata\.ai\/get-transcript/i);
+  assert.match(readme, /dash\.supadata\.ai\/auth\/sign-up/i);
+  assert.match(readme, /platform\.deepseek\.com\/api_keys/i);
+  assert.match(readme, /api-docs\.deepseek\.com/i);
+  assert.match(chineseReadme, /dash\.supadata\.ai\/auth\/sign-up/i);
+  assert.match(chineseReadme, /platform\.deepseek\.com\/api_keys/i);
+  assert.match(readme, /^### The Digest button is missing on a YouTube video$/m);
+  assert.match(
+    chineseReadme,
+    /^### YouTube 视频页面没有显示 Digest 按钮$/m,
+  );
+
+  const optionsPage = read("options.html");
+  const optionsScript = read("options.js");
+  assert.match(optionsPage, /dash\.supadata\.ai\/auth\/sign-up/i);
+  assert.match(optionsPage, /platform\.deepseek\.com\/api_keys/i);
+  assert.match(optionsScript, /platform\.deepseek\.com\/api_keys/i);
 
   assert.match(readme, /^## Remix it with your coding agent$/m);
   assert.match(readme, /more translation languages/i);


### PR DESCRIPTION
## What changed

- reposition the Digest button beside YouTube's native menu and reconcile it on responsive layout changes
- ignore hidden responsive action bars, replace stale button instances, and prevent duplicates
- add DOM regression tests for hidden, replaced, and resized YouTube toolbars
- rewrite the English and Chinese product opening around deep learning
- add exact Supadata and DeepSeek API key links and beginner setup steps in the READMEs and Settings
- add Digest button troubleshooting and bump the extension to v1.1.1

## Why

YouTube can keep a hidden 0 by 0 action toolbar before the visible toolbar in the DOM. The previous code selected that hidden element and treated the invisible button as successfully installed. It also placed Digest at the end of YouTube's shrinkable native button list, where narrow layouts could clip it.

## Validation

- `npm test` with 34 passing tests
- `npm run check` with 23 allowlisted release files
- `npm run package`
- `git diff --check`
- reproduced the hidden-first toolbar ordering on a real YouTube watch page at a 700px Chrome viewport

Chrome automation does not allow opening `chrome://extensions`, so reloading the unpacked extension remains a final user-side smoke test.
