### PR TITLE
Keep the Digest button compact

### DIFF
--- a/content.js
+++ b/content.js
@@ -192,15 +192,22 @@ function isVisibleDigestHost(element) {
 /**
  * YouTube keeps hidden copies of its responsive action toolbar in the DOM.
  * querySelector() can return one of those 0x0 copies before the toolbar the
- * viewer can actually see, so inspect every candidate and prefer the visible
- * #actions-inner that belongs to the current video's metadata.
+ * viewer can actually see, so inspect every candidate and resolve the native
+ * button group inside the visible action row for the current video.
  */
 function findDigestButtonHost() {
   const primaryActionRows = Array.from(
     document.querySelectorAll("ytd-watch-metadata #actions-inner"),
   );
-  const visibleActionRow = primaryActionRows.find(isVisibleDigestHost);
-  if (visibleActionRow) return visibleActionRow;
+
+  for (const actionRow of primaryActionRows) {
+    if (!isVisibleDigestHost(actionRow)) continue;
+
+    const visibleButtonGroup = Array.from(
+      actionRow.querySelectorAll("#top-level-buttons-computed"),
+    ).find(isVisibleDigestHost);
+    if (visibleButtonGroup) return visibleButtonGroup;
+  }
 
   const fallbackCandidates = Array.from(
     document.querySelectorAll(
@@ -246,10 +253,15 @@ function createDigestButton() {
     font-size: 14px;
     font-weight: 600;
     cursor: pointer;
-    margin-left: 8px;
+    margin-right: 8px;
     transition: background 0.2s, transform 0.1s, box-shadow 0.2s;
     box-shadow: 0 2px 8px rgba(200, 103, 79, 0.3);
-    flex-shrink: 0;
+    flex: 0 0 auto;
+    align-self: center;
+    width: max-content;
+    min-width: max-content;
+    max-width: max-content;
+    white-space: nowrap;
   `;
 
   // Hover effects
@@ -322,15 +334,11 @@ function injectDigestButton() {
   });
 
   if (digestButton.parentElement !== actionsContainer) {
-    // #actions-inner is outside YouTube's horizontally shrinkable native
-    // button list. Keeping Digest as its own sibling prevents it from being
-    // clipped when the watch page gets narrow. The fallback host uses prepend
-    // so Digest receives visibility priority on older YouTube layouts.
-    if (actionsContainer.id === "actions-inner") {
-      actionsContainer.appendChild(digestButton);
-    } else {
-      actionsContainer.insertBefore(digestButton, actionsContainer.firstChild);
-    }
+    // YouTube turns #actions-inner into a vertical flex column at narrow
+    // breakpoints. A direct child there stretches into a full-width second
+    // row, so keep Digest inside the native horizontal button group and
+    // prepend it to preserve visibility when space is limited.
+    actionsContainer.insertBefore(digestButton, actionsContainer.firstChild);
   }
 
   debugLog("[YouTube Digest Content] Digest button reconciled");

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Digest",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "minimum_chrome_version": "116",
   "description": "Turn YouTube videos into learning resources with transcripts, bilingual translation, AI overviews, and notes.",
   "permissions": ["sidePanel", "storage", "tabs", "scripting"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-digest",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "Turn YouTube videos into learning resources with transcripts, bilingual translation, AI overviews, and notes.",
   "license": "MIT",

--- a/tests/digest-button.test.js
+++ b/tests/digest-button.test.js
@@ -43,6 +43,22 @@ class FakeElement {
     return null;
   }
 
+  querySelectorAll(selector) {
+    const matches = [];
+
+    for (const child of this.children) {
+      if (
+        selector === "#top-level-buttons-computed" &&
+        child.id === selector.slice(1)
+      ) {
+        matches.push(child);
+      }
+      matches.push(...child.querySelectorAll(selector));
+    }
+
+    return matches;
+  }
+
   addEventListener(type, listener) {
     this.listeners[type] = listener;
   }
@@ -181,45 +197,58 @@ function createHarness() {
   };
 }
 
+function createActionRow({ width, height }) {
+  const row = new FakeElement({
+    id: "actions-inner",
+    width,
+    height,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  const buttonGroup = new FakeElement({
+    id: "top-level-buttons-computed",
+    width,
+    height,
+    inMetadata: true,
+    inPrimary: true,
+  });
+  row.appendChild(buttonGroup);
+  return { row, buttonGroup };
+}
+
 test("Digest button skips a hidden responsive toolbar", () => {
   const harness = createHarness();
-  const hiddenRow = new FakeElement({
-    id: "actions-inner",
+  const { row: hiddenRow, buttonGroup: hiddenGroup } = createActionRow({
     width: 0,
     height: 0,
-    inMetadata: true,
-    inPrimary: true,
   });
-  const visibleRow = new FakeElement({
-    id: "actions-inner",
+  const { row: visibleRow, buttonGroup: visibleGroup } = createActionRow({
     width: 389,
     height: 36,
-    inMetadata: true,
-    inPrimary: true,
   });
+  const nativeButton = new FakeElement();
+  visibleGroup.appendChild(nativeButton);
   harness.actionRows.push(hiddenRow, visibleRow);
 
-  assert.equal(harness.context.findDigestButtonHost(), visibleRow);
+  assert.equal(harness.context.findDigestButtonHost(), visibleGroup);
   assert.equal(harness.context.injectDigestButton(), true);
-  assert.equal(hiddenRow.children.length, 0);
-  assert.equal(visibleRow.children[0].id, "ytd-digest-button");
+  assert.equal(hiddenGroup.children.length, 0);
+  assert.equal(visibleRow.children.length, 1);
+  assert.equal(visibleGroup.children[0].id, "ytd-digest-button");
+  assert.equal(visibleGroup.children[1], nativeButton);
+  assert.match(visibleGroup.children[0].style.cssText, /flex:\s*0 0 auto/);
+  assert.match(visibleGroup.children[0].style.cssText, /width:\s*max-content/);
 });
 
 test("Digest button replaces stale instances and removes duplicates", () => {
   const harness = createHarness();
-  const staleRow = new FakeElement({
-    id: "actions-inner",
+  const { row: staleRow, buttonGroup: staleGroup } = createActionRow({
     width: 0,
     height: 0,
-    inMetadata: true,
-    inPrimary: true,
   });
-  const visibleRow = new FakeElement({
-    id: "actions-inner",
+  const { row: visibleRow, buttonGroup: visibleGroup } = createActionRow({
     width: 500,
     height: 36,
-    inMetadata: true,
-    inPrimary: true,
   });
   harness.actionRows.push(staleRow, visibleRow);
 
@@ -228,33 +257,28 @@ test("Digest button replaces stale instances and removes duplicates", () => {
   const duplicateButton = new FakeElement();
   duplicateButton.id = "ytd-digest-button";
   harness.elements.push(staleButton, duplicateButton);
-  staleRow.appendChild(staleButton);
-  staleRow.appendChild(duplicateButton);
+  staleGroup.appendChild(staleButton);
+  staleGroup.appendChild(duplicateButton);
 
   assert.equal(harness.context.injectDigestButton(), true);
-  assert.equal(staleRow.children.length, 0);
+  assert.equal(staleGroup.children.length, 0);
   assert.equal(visibleRow.children.length, 1);
-  assert.notEqual(visibleRow.children[0], staleButton);
-  assert.equal(visibleRow.children[0].id, "ytd-digest-button");
+  assert.equal(visibleGroup.children.length, 1);
+  assert.notEqual(visibleGroup.children[0], staleButton);
+  assert.equal(visibleGroup.children[0].id, "ytd-digest-button");
   assert.equal(staleButton.isConnected, false);
   assert.equal(duplicateButton.isConnected, false);
 });
 
 test("resize reconciliation follows YouTube to the newly visible toolbar", () => {
   const harness = createHarness();
-  const firstRow = new FakeElement({
-    id: "actions-inner",
+  const { row: firstRow, buttonGroup: firstGroup } = createActionRow({
     width: 500,
     height: 36,
-    inMetadata: true,
-    inPrimary: true,
   });
-  const secondRow = new FakeElement({
-    id: "actions-inner",
+  const { row: secondRow, buttonGroup: secondGroup } = createActionRow({
     width: 0,
     height: 0,
-    inMetadata: true,
-    inPrimary: true,
   });
   harness.actionRows.push(firstRow, secondRow);
 
@@ -262,32 +286,31 @@ test("resize reconciliation follows YouTube to the newly visible toolbar", () =>
   harness.context.setupDigestButtonResizeListener();
   firstRow.width = 0;
   firstRow.height = 0;
+  firstGroup.width = 0;
+  firstGroup.height = 0;
   secondRow.width = 389;
   secondRow.height = 36;
+  secondGroup.width = 389;
+  secondGroup.height = 36;
 
   harness.windowListeners.resize();
   harness.flushTimers();
 
-  assert.equal(firstRow.children.length, 0);
+  assert.equal(firstGroup.children.length, 0);
   assert.equal(secondRow.children.length, 1);
-  assert.equal(secondRow.children[0].id, "ytd-digest-button");
+  assert.equal(secondGroup.children.length, 1);
+  assert.equal(secondGroup.children[0].id, "ytd-digest-button");
 });
 
 test("DOM mutation reconciliation repairs a replaced toolbar", () => {
   const harness = createHarness();
-  const oldRow = new FakeElement({
-    id: "actions-inner",
+  const { row: oldRow, buttonGroup: oldGroup } = createActionRow({
     width: 500,
     height: 36,
-    inMetadata: true,
-    inPrimary: true,
   });
-  const newRow = new FakeElement({
-    id: "actions-inner",
+  const { row: newRow, buttonGroup: newGroup } = createActionRow({
     width: 0,
     height: 0,
-    inMetadata: true,
-    inPrimary: true,
   });
   harness.actionRows.push(oldRow, newRow);
 
@@ -295,12 +318,17 @@ test("DOM mutation reconciliation repairs a replaced toolbar", () => {
   harness.context.setupButtonObserver();
   oldRow.width = 0;
   oldRow.height = 0;
+  oldGroup.width = 0;
+  oldGroup.height = 0;
   newRow.width = 500;
   newRow.height = 36;
+  newGroup.width = 500;
+  newGroup.height = 36;
 
   harness.observers[0].callback([]);
   harness.flushTimers();
 
-  assert.equal(oldRow.children.length, 0);
+  assert.equal(oldGroup.children.length, 0);
   assert.equal(newRow.children.length, 1);
+  assert.equal(newGroup.children.length, 1);
 });


### PR DESCRIPTION
## What changed

- insert Digest inside YouTube's visible horizontal native button group
- prepend the button so it stays visible at narrow widths
- constrain the pill to intrinsic width with defensive flex sizing
- preserve hidden-toolbar, resize, navigation, and stale-button reconciliation
- update regression tests for nested responsive button groups
- bump the extension to v1.1.2

## Root cause

At narrow YouTube breakpoints, `#actions-inner` changes to a vertical flex column. v1.1.1 inserted Digest as a direct child of that column, so browser cross-axis stretching turned it into a full-width second row.

## Validation

- reproduced the column layout at 980px and 700px on the reported YouTube video
- confirmed the selected `#top-level-buttons-computed` host remains a horizontal centered flex row
- `npm test` with 34 passing tests
- `npm run check`
- `npm run package`
- `node --check content.js`
- `git diff --check`
