### PR TITLE
Improve settings action spacing

### DIFF
--- a/options.css
+++ b/options.css
@@ -136,6 +136,10 @@ a {
   gap: 10px;
 }
 
+.data-actions {
+  margin-top: 18px;
+}
+
 button {
   padding: 10px 15px;
   border: 1px solid var(--border);


### PR DESCRIPTION
## What changed

- Added an 18px vertical gap between the Local data description and its pill-button row.
- Kept the Save settings action row and other cards unchanged.

## Why

The Local data description was visually crowded against the buttons.

## Validation

- Rendered and visually inspected the Settings page.
- Confirmed an exact 18px computed gap.
- npm test: 34 passed.
- npm run check: release validation passed with 22 allowlisted files.
- git diff --check passed.