### PR TITLE
Add bilingual Settings interface

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Digest",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "minimum_chrome_version": "116",
   "description": "Turn YouTube videos into learning resources with transcripts, bilingual translation, AI overviews, and notes.",
   "permissions": ["sidePanel", "storage", "tabs", "scripting"],

--- a/options.css
+++ b/options.css
@@ -32,6 +32,49 @@ header {
   margin-bottom: 28px;
 }
 
+.settings-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.language-switch {
+  display: inline-flex;
+  flex: 0 0 auto;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.language-switch .language-option {
+  min-width: 62px;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.language-switch .language-option:hover {
+  border-color: transparent;
+  color: var(--text);
+}
+
+.language-switch .language-option[aria-pressed="true"] {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 4px rgba(46, 42, 36, 0.14);
+}
+
+.language-switch .language-option:focus-visible {
+  outline: 3px solid rgba(200, 103, 79, 0.28);
+  outline-offset: 1px;
+}
+
 .eyebrow {
   color: var(--accent);
   font-size: 12px;
@@ -224,10 +267,34 @@ a {
   border-top: 1px solid #ead8d0;
 }
 
-.customization-copy {
+.customization-intro {
   max-width: 650px;
-  margin: 0 0 6px;
+  margin: 0;
   font-size: 14px;
+}
+
+.customization-steps {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0 18px;
+  padding-left: 22px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.customization-steps li {
+  padding-left: 4px;
+}
+
+.prompt-reminder {
+  margin: 8px 0 10px;
+  padding: 10px 12px;
+  border: 1px solid #e7b9a8;
+  border-radius: 10px;
+  background: #fff2ec;
+  color: #60483f;
+  font-size: 13px;
+  font-weight: 750;
 }
 
 .copy-actions {
@@ -298,6 +365,15 @@ footer {
 
   .card {
     padding: 19px;
+  }
+
+  .settings-heading-row {
+    align-items: flex-start;
+  }
+
+  .language-switch .language-option {
+    min-width: 56px;
+    padding-inline: 8px;
   }
 
   .customization-card {

--- a/options.html
+++ b/options.html
@@ -9,9 +9,34 @@
   <body>
     <main class="settings-shell">
       <header>
-        <div class="eyebrow">YouTube Digest</div>
-        <h1>Bring your own API keys</h1>
-        <p class="lede">
+        <div class="settings-heading-row">
+          <div class="eyebrow">YouTube Digest</div>
+          <div
+            class="language-switch"
+            role="group"
+            aria-label="Interface language"
+            data-i18n-aria-label="languageGroupLabel"
+          >
+            <button
+              class="language-option"
+              type="button"
+              data-language="en"
+              aria-pressed="true"
+            >
+              English
+            </button>
+            <button
+              class="language-option"
+              type="button"
+              data-language="zh-CN"
+              aria-pressed="false"
+            >
+              中文
+            </button>
+          </div>
+        </div>
+        <h1 data-i18n="heading">Bring your own API keys</h1>
+        <p class="lede" data-i18n="lede">
           Keys stay in this Chrome profile and are sent only to Supadata and
           DeepSeek. This open-source extension has no developer server or
           analytics.
@@ -20,8 +45,10 @@
 
       <form id="settingsForm">
         <section class="card">
-          <h2>Transcript provider</h2>
-          <label for="supadataApiKey">Supadata API key</label>
+          <h2 data-i18n="transcriptProvider">Transcript provider</h2>
+          <label for="supadataApiKey" data-i18n="supadataApiKeyLabel"
+            >Supadata API key</label
+          >
           <input
             id="supadataApiKey"
             name="supadataApiKey"
@@ -31,24 +58,37 @@
             placeholder="Paste your Supadata key"
           />
           <p class="help">
-            Used to fetch timestamped YouTube subtitles.
+            <span data-i18n="supadataHelp"
+              >Used to fetch timestamped YouTube subtitles.</span
+            >
             <a
               href="https://dash.supadata.ai/auth/sign-up"
               target="_blank"
               rel="noreferrer"
+              data-i18n="supadataLink"
               >Create a Supadata account and key</a
-            >. Supadata generates the key during onboarding.
+            ><span data-i18n="supadataHelpSuffix"
+              >. Supadata generates the key during onboarding.</span
+            >
           </p>
         </section>
 
         <section class="card">
-          <h2>AI provider</h2>
-          <div class="provider-summary" aria-label="Supported AI provider">
+          <h2 data-i18n="aiProvider">AI provider</h2>
+          <div
+            class="provider-summary"
+            aria-label="Supported AI provider"
+            data-i18n-aria-label="providerSummaryLabel"
+          >
             <span class="provider-name">DeepSeek V4 Flash</span>
-            <span class="provider-badge">Supported in this version</span>
+            <span class="provider-badge" data-i18n="providerBadge"
+              >Supported in this version</span
+            >
           </div>
 
-          <label for="aiApiKey">DeepSeek API key</label>
+          <label for="aiApiKey" data-i18n="deepseekApiKeyLabel"
+            >DeepSeek API key</label
+          >
           <input
             id="aiApiKey"
             name="aiApiKey"
@@ -58,16 +98,19 @@
             placeholder="Paste your DeepSeek key"
           />
           <p class="help">
-            YouTube Digest uses DeepSeek V4 Flash for overviews,
-            explanations, translation, and note polishing.
+            <span data-i18n="deepseekHelp"
+              >YouTube Digest uses DeepSeek V4 Flash for overviews,
+              explanations, translation, and note polishing.</span
+            >
             <a
               href="https://platform.deepseek.com/api_keys"
               target="_blank"
               rel="noreferrer"
+              data-i18n="deepseekLink"
               >Create a DeepSeek API key</a
-            >.
+            ><span data-i18n="deepseekHelpSuffix">.</span>
           </p>
-          <div class="privacy-note">
+          <div class="privacy-note" data-i18n="privacyNote">
             When you use AI features, DeepSeek receives the video transcript
             and relevant video context. Review DeepSeek's terms and pricing
             before saving.
@@ -75,7 +118,9 @@
         </section>
 
         <div class="form-actions">
-          <button class="primary" type="submit">Save settings</button>
+          <button class="primary" type="submit" data-i18n="saveSettings">
+            Save settings
+          </button>
           <span id="saveStatus" role="status" aria-live="polite"></span>
         </div>
       </form>
@@ -83,36 +128,62 @@
       <details class="card customization-card">
         <summary class="customization-summary">
           <span class="customization-summary-copy">
-            <span class="eyebrow">Local remix</span>
-            <span class="customization-title"
+            <span class="eyebrow" data-i18n="localRemix">Local remix</span>
+            <span class="customization-title" data-i18n="customizationTitle"
               >Want to use another AI model?</span
             >
-            <span class="customization-purpose"
-              >Copy a safe prompt for your coding agent</span
+            <span
+              class="customization-purpose"
+              data-i18n="customizationPurpose"
+              >Edit and copy a safe prompt for your coding agent</span
             >
           </span>
-          <span class="agent-badge">Coding agent ready</span>
+          <span class="agent-badge" data-i18n="agentBadge"
+            >Coding agent ready</span
+          >
         </summary>
         <div class="customization-content">
-          <p class="help customization-copy">
-            This published version supports DeepSeek V4 Flash. You can adapt
-            your own local copy with a coding agent. Before copying, open the
-            exact YouTube Digest project folder that Chrome loaded through
-            Load unpacked in your coding agent. Then expand this section and
-            copy the prompt. For a first-time installation, optional permanent
-            locations include <code>~/Documents/youtube-digest</code> on macOS
-            or Linux, or
-            <code>%USERPROFILE%\Documents\youtube-digest</code> on Windows.
-            These are suggestions, not assumed paths. Chrome and the extension
-            cannot reliably reveal or copy the actual OS path. Never include
-            API keys in the prompt or chat. Enter them yourself only after the
-            code is ready.
+          <p class="help customization-intro" data-i18n="customizationIntro">
+            You can edit the prompt directly. Complete these three steps before
+            copying:
           </p>
-          <label for="customizationPrompt">Safe customization prompt</label>
-          <textarea id="customizationPrompt" readonly rows="12">Customize my local copy of YouTube Digest to use [PROVIDER] with [MODEL]. Work only in the currently open workspace. Before editing anything, verify that this workspace contains manifest.json and that its name is YouTube Digest. If verification fails, stop and tell me: "Open the exact YouTube Digest project folder that Chrome loaded through Load unpacked in your coding agent, then paste this prompt again." Do not search other folders or the whole disk, edit a guessed copy, assume an installation path, or claim that Chrome or the extension can reveal the absolute OS source path. Update the API endpoint, request format, and minimum Chrome host permissions needed for that provider. Preserve the bring-your-own-key model and local Chrome storage. Keep all API keys out of source code, commits, logs, screenshots, and this chat; after the code is ready, tell me where I should enter the key myself. Keep DeepSeek-specific fields and retries provider-scoped, update README.md, README.zh-CN.md, PRIVACY.md, SECURITY.md, and the tests, then run npm test, npm run check, and npm run package. Finally, explain how to reload the unpacked extension and test it on a real YouTube video.</textarea>
+          <ol class="customization-steps">
+            <li data-i18n="customizationStepFolder">
+              Open the extracted YouTube Digest project folder in your coding
+              agent.
+            </li>
+            <li data-i18n="customizationStepReplace">
+              Replace [PROVIDER] and [MODEL] with the service and model you want
+              to use.
+            </li>
+            <li data-i18n="customizationStepKeys">
+              Never include API keys in the prompt or chat. Enter them yourself
+              after the code is ready.
+            </li>
+          </ol>
+          <label for="customizationPrompt" data-i18n="customizationPromptLabel"
+            >Editable customization prompt</label
+          >
+          <div
+            id="customizationPromptReminder"
+            class="prompt-reminder"
+            role="note"
+            aria-label="Prompt reminder"
+            data-i18n-aria-label="customizationReminderLabel"
+          >
+            <span data-i18n="customizationReminder"
+              >Before copying, replace [PROVIDER] and [MODEL] with the provider
+              and model you want to use.</span
+            >
+          </div>
+          <textarea id="customizationPrompt" rows="12" aria-describedby="customizationPromptReminder">Customize this local YouTube Digest workspace to use [PROVIDER] with [MODEL]. Work only in the current workspace. Before editing, verify that it contains manifest.json and that the manifest name is YouTube Digest. If verification fails, stop and ask me to open the extracted YouTube Digest project folder in my coding agent. Do not search other folders, edit a guessed copy, assume an installation path, or claim Chrome can reveal the absolute OS source path. Update the provider's API endpoint, request format, and minimum Chrome host permissions. Preserve bring-your-own-key and local Chrome storage. Never put API keys in source code, commits, logs, screenshots, this prompt, or chat; after the code is ready, tell me where to enter the key myself. Keep DeepSeek-only request fields and retry behavior isolated to DeepSeek. Handle provider-specific rules separately so one provider does not affect another. Update README.md, README.zh-CN.md, PRIVACY.md, SECURITY.md, and tests. Run npm test, npm run check, and npm run package. Then explain how to reload the unpacked extension and test it on a real YouTube video.</textarea>
           <div class="copy-actions">
-            <button id="copyCustomizationPromptBtn" type="button">
-              Copy customization prompt
+            <button
+              id="copyCustomizationPromptBtn"
+              type="button"
+              data-i18n="copyCustomizationPrompt"
+            >
+              Copy edited prompt
             </button>
             <span id="copyStatus" role="status" aria-live="polite"></span>
           </div>
@@ -120,22 +191,31 @@
       </details>
 
       <section class="card data-card">
-        <h2>Local data</h2>
-        <p class="help">
+        <h2 data-i18n="localData">Local data</h2>
+        <p class="help" data-i18n="localDataHelp">
           Digests, translations, and notes are stored only in this Chrome
           profile. You can remove them at any time.
         </p>
         <div class="data-actions">
-          <button id="clearCacheBtn" type="button">Clear cached digests</button>
-          <button id="clearNotesBtn" type="button">Delete all notes</button>
-          <button id="resetBtn" class="danger" type="button">
+          <button id="clearCacheBtn" type="button" data-i18n="clearCache">
+            Clear cached digests
+          </button>
+          <button id="clearNotesBtn" type="button" data-i18n="deleteNotes">
+            Delete all notes
+          </button>
+          <button
+            id="resetBtn"
+            class="danger"
+            type="button"
+            data-i18n="resetData"
+          >
             Reset extension data
           </button>
         </div>
         <span id="dataStatus" role="status" aria-live="polite"></span>
       </section>
 
-      <footer>
+      <footer data-i18n-html="footer">
         Read <a href="PRIVACY.md" target="_blank">PRIVACY.md</a> in the
         repository for the complete data-flow description.
       </footer>

--- a/options.js
+++ b/options.js
@@ -1,100 +1,554 @@
-const form = document.getElementById("settingsForm");
-const aiApiKeyInput = document.getElementById("aiApiKey");
-const supadataApiKeyInput = document.getElementById("supadataApiKey");
-const customizationPrompt = document.getElementById("customizationPrompt");
-const copyCustomizationPromptBtn = document.getElementById(
-  "copyCustomizationPromptBtn",
-);
-const copyStatus = document.getElementById("copyStatus");
-const saveStatus = document.getElementById("saveStatus");
-const dataStatus = document.getElementById("dataStatus");
+const YTD_OPTIONS = (() => {
+  const LANGUAGE_STORAGE_KEY = "ytd_options_language";
+  const PREVIEW_STORAGE_PREFIX = "youtubeDigestPreview:";
+  const SUPPORTED_LANGUAGES = new Set(["en", "zh-CN"]);
 
-document.addEventListener("DOMContentLoaded", loadSettings);
-form.addEventListener("submit", saveSettings);
-copyCustomizationPromptBtn.addEventListener("click", copyCustomizationPrompt);
-document
-  .getElementById("clearCacheBtn")
-  .addEventListener("click", clearCachedDigests);
-document
-  .getElementById("clearNotesBtn")
-  .addEventListener("click", clearNotes);
-document.getElementById("resetBtn").addEventListener("click", resetAllData);
+  const COPY = {
+    en: {
+      pageTitle: "YouTube Digest Settings",
+      languageGroupLabel: "Interface language",
+      heading: "Bring your own API keys",
+      lede:
+        "Keys stay in this Chrome profile and are sent only to Supadata and DeepSeek. This open-source extension has no developer server or analytics.",
+      transcriptProvider: "Transcript provider",
+      supadataApiKeyLabel: "Supadata API key",
+      supadataHelp: "Used to fetch timestamped YouTube subtitles. ",
+      supadataLink: "Create a Supadata account and key",
+      supadataHelpSuffix:
+        ". Supadata generates the key during onboarding.",
+      aiProvider: "AI provider",
+      providerSummaryLabel: "Supported AI provider",
+      providerBadge: "Supported in this version",
+      deepseekApiKeyLabel: "DeepSeek API key",
+      deepseekHelp:
+        "YouTube Digest uses DeepSeek V4 Flash for overviews, explanations, translation, and note polishing. ",
+      deepseekLink: "Create a DeepSeek API key",
+      deepseekHelpSuffix: ".",
+      privacyNote:
+        "When you use AI features, DeepSeek receives the video transcript and relevant video context. Review DeepSeek's terms and pricing before saving.",
+      saveSettings: "Save settings",
+      localRemix: "Local remix",
+      customizationTitle: "Want to use another AI model?",
+      customizationPurpose: "Edit and copy a safe prompt for your coding agent",
+      agentBadge: "Coding agent ready",
+      customizationIntro:
+        "You can edit the prompt directly. Complete these three steps before copying:",
+      customizationStepFolder:
+        "Open the extracted YouTube Digest project folder in your coding agent.",
+      customizationStepReplace:
+        "Replace [PROVIDER] and [MODEL] with the service and model you want to use.",
+      customizationStepKeys:
+        "Never include API keys in the prompt or chat. Enter them yourself after the code is ready.",
+      customizationPromptLabel: "Editable customization prompt",
+      customizationReminderLabel: "Prompt reminder",
+      customizationReminder:
+        "Before copying, replace [PROVIDER] and [MODEL] with the provider and model you want to use.",
+      customizationPrompt:
+        "Customize this local YouTube Digest workspace to use [PROVIDER] with [MODEL]. Work only in the current workspace. Before editing, verify that it contains manifest.json and that the manifest name is YouTube Digest. If verification fails, stop and ask me to open the extracted YouTube Digest project folder in my coding agent. Do not search other folders, edit a guessed copy, assume an installation path, or claim Chrome can reveal the absolute OS source path. Update the provider's API endpoint, request format, and minimum Chrome host permissions. Preserve bring-your-own-key and local Chrome storage. Never put API keys in source code, commits, logs, screenshots, this prompt, or chat; after the code is ready, tell me where to enter the key myself. Keep DeepSeek-only request fields and retry behavior isolated to DeepSeek. Handle provider-specific rules separately so one provider does not affect another. Update README.md, README.zh-CN.md, PRIVACY.md, SECURITY.md, and tests. Run npm test, npm run check, and npm run package. Then explain how to reload the unpacked extension and test it on a real YouTube video.",
+      copyCustomizationPrompt: "Copy edited prompt",
+      localData: "Local data",
+      localDataHelp:
+        "Digests, translations, and notes are stored only in this Chrome profile. You can remove them at any time.",
+      clearCache: "Clear cached digests",
+      deleteNotes: "Delete all notes",
+      resetData: "Reset extension data",
+      footer:
+        'Read <a href="PRIVACY.md" target="_blank">PRIVACY.md</a> in the repository for the complete data-flow description.',
+      migrationWarning:
+        "Custom provider settings were removed safely. Your Supadata key was kept, but the AI key was cleared. Enter a DeepSeek API key to continue.",
+      saving: "Saving…",
+      addSupadataKey: "Add a Supadata API key.",
+      addDeepseekKey: "Add a DeepSeek API key.",
+      saved: "Saved. Reopen YouTube Digest to use these settings.",
+      saveFailed: "Could not save settings. Please try again.",
+      copying: "Copying…",
+      promptCopied: "Edited prompt copied.",
+      copyFailed:
+        "Could not copy the prompt. Select the prompt text and copy it manually.",
+      clearedDigests: ({ count }) =>
+        `Cleared ${count} cached digest${count === 1 ? "" : "s"}.`,
+      notesDeleted: "Deleted all saved notes.",
+      resetConfirm:
+        "Delete API keys, cached digests, translations, and saved notes from this Chrome profile?",
+      allDataDeleted: "All YouTube Digest data was deleted.",
+      settingsLoadFailed:
+        "Could not load saved settings. You can still preview this page.",
+    },
+    "zh-CN": {
+      pageTitle: "YouTube Digest 设置",
+      languageGroupLabel: "界面语言",
+      heading: "使用你自己的 API 密钥",
+      lede:
+        "密钥仅保存在当前 Chrome 个人资料中，只会发送给 Supadata 和 DeepSeek。本开源扩展没有开发者服务器，也不使用分析服务。",
+      transcriptProvider: "字幕服务",
+      supadataApiKeyLabel: "Supadata API 密钥",
+      supadataHelp: "用于获取带时间戳的 YouTube 字幕。",
+      supadataLink: "创建 Supadata 账号并获取密钥",
+      supadataHelpSuffix: "。Supadata 会在引导流程中生成密钥。",
+      aiProvider: "AI 服务",
+      providerSummaryLabel: "支持的 AI 服务",
+      providerBadge: "当前版本支持",
+      deepseekApiKeyLabel: "DeepSeek API 密钥",
+      deepseekHelp:
+        "YouTube Digest 使用 DeepSeek V4 Flash 生成概览、解释内容、翻译字幕和润色笔记。",
+      deepseekLink: "创建 DeepSeek API 密钥",
+      deepseekHelpSuffix: "。",
+      privacyNote:
+        "使用 AI 功能时，DeepSeek 会收到视频字幕及相关视频上下文。保存前请查看 DeepSeek 的服务条款和价格。",
+      saveSettings: "保存设置",
+      localRemix: "本地改造",
+      customizationTitle: "想使用其他 AI 模型？",
+      customizationPurpose: "编辑并复制一段可安全交给编程 Agent 的提示词",
+      agentBadge: "可交给编程 Agent",
+      customizationIntro: "你可以直接编辑提示词。复制前完成以下三步：",
+      customizationStepFolder:
+        "在编程 Agent 中打开 YouTube Digest 解压后的项目文件夹。",
+      customizationStepReplace:
+        "把 [PROVIDER] 和 [MODEL] 替换成你想使用的服务和模型。",
+      customizationStepKeys:
+        "不要在提示词或聊天中加入 API 密钥。代码准备好后，请自行填写。",
+      customizationPromptLabel: "可编辑的自定义提示词",
+      customizationReminderLabel: "提示词提醒",
+      customizationReminder:
+        "复制前，请先把 [PROVIDER] 和 [MODEL] 替换成你想使用的服务和模型。",
+      customizationPrompt:
+        "请把当前本地 YouTube Digest 工作区改为使用 [PROVIDER] 提供的 [MODEL]。只在当前工作区中操作。编辑前，先确认其中包含 manifest.json，且 manifest 中的 name 是 YouTube Digest。如果验证失败，请停止，并让我在编程 Agent 中打开 YouTube Digest 解压后的项目文件夹。不要搜索其他文件夹，不要编辑猜测的副本，不要假设安装路径，也不要声称 Chrome 可以显示操作系统中的绝对源码路径。更新该服务的 API endpoint、请求格式和最少的 Chrome host permissions。保留用户自带密钥模式和 Chrome 本地存储。不要把 API 密钥写入源代码、提交记录、日志、截图、这段提示词或聊天；代码准备好后，请告诉我应该在哪里自行填写密钥。DeepSeek 专用的请求参数和重试逻辑继续只用于 DeepSeek。新服务的专属规则请单独处理，避免相互影响。更新 README.md、README.zh-CN.md、PRIVACY.md、SECURITY.md 和测试。运行 npm test、npm run check 和 npm run package。最后，说明如何重新加载已解压的扩展，并在真实 YouTube 视频上测试。",
+      copyCustomizationPrompt: "复制编辑后的提示词",
+      localData: "本地数据",
+      localDataHelp:
+        "摘要、翻译和笔记仅保存在当前 Chrome 个人资料中。你可以随时删除。",
+      clearCache: "清除缓存的摘要",
+      deleteNotes: "删除全部笔记",
+      resetData: "重置扩展数据",
+      footer:
+        '完整数据流说明请参阅仓库中的 <a href="PRIVACY.md" target="_blank">PRIVACY.md</a>。',
+      migrationWarning:
+        "已安全移除自定义服务设置。Supadata 密钥已保留，AI 密钥已清除。请输入 DeepSeek API 密钥以继续使用。",
+      saving: "正在保存…",
+      addSupadataKey: "请添加 Supadata API 密钥。",
+      addDeepseekKey: "请添加 DeepSeek API 密钥。",
+      saved: "已保存。请重新打开 YouTube Digest 以使用这些设置。",
+      saveFailed: "无法保存设置，请重试。",
+      copying: "正在复制…",
+      promptCopied: "已复制编辑后的提示词。",
+      copyFailed: "无法复制提示词。请选中提示词文本并手动复制。",
+      clearedDigests: ({ count }) => `已清除 ${count} 条缓存摘要。`,
+      notesDeleted: "已删除全部已保存的笔记。",
+      resetConfirm:
+        "要从当前 Chrome 个人资料中删除 API 密钥、缓存摘要、翻译和已保存的笔记吗？",
+      allDataDeleted: "已删除全部 YouTube Digest 数据。",
+      settingsLoadFailed: "无法加载已保存的设置，但你仍可预览此页面。",
+    },
+  };
 
-async function loadSettings() {
-  const stored = await chrome.storage.local.get(YTD_SETTINGS.STORAGE_KEY);
-  const migration = YTD_SETTINGS.migrateLegacyCustom(
-    stored[YTD_SETTINGS.STORAGE_KEY],
-  );
-  const settings = migration.settings;
-
-  aiApiKeyInput.value = settings.aiApiKey;
-  supadataApiKeyInput.value = settings.supadataApiKey;
-  if (migration.migrated) {
-    await chrome.storage.local.set({
-      [YTD_SETTINGS.STORAGE_KEY]: settings,
-    });
-    saveStatus.textContent =
-      "Custom provider settings were removed safely. Your Supadata key was kept, but the AI key was cleared. Enter a DeepSeek API key to continue.";
+  function normalizeLanguage(language) {
+    return SUPPORTED_LANGUAGES.has(language) ? language : "en";
   }
-}
 
-async function saveSettings(event) {
-  event.preventDefault();
-  saveStatus.textContent = "Saving…";
+  function translate(language, key, params = {}) {
+    const normalizedLanguage = normalizeLanguage(language);
+    const value = COPY[normalizedLanguage][key] ?? COPY.en[key] ?? "";
+    return typeof value === "function" ? value(params) : value;
+  }
 
-  try {
-    const settings = YTD_SETTINGS.normalize({
-      aiApiKey: aiApiKeyInput.value,
-      supadataApiKey: supadataApiKeyInput.value,
-    });
+  function createStorageAdapter(chromeApi, fallbackStorage) {
+    const chromeStorage = chromeApi?.storage?.local;
+    const memoryStorage = new Map();
 
-    if (!settings.supadataApiKey) {
-      throw new Error("Add a Supadata API key.");
+    function fallbackKeys() {
+      const keys = [];
+      if (!fallbackStorage) return keys;
+      try {
+        for (let index = 0; index < fallbackStorage.length; index += 1) {
+          const key = fallbackStorage.key(index);
+          if (key?.startsWith(PREVIEW_STORAGE_PREFIX)) keys.push(key);
+        }
+      } catch (_error) {
+        return [];
+      }
+      return keys;
     }
-    if (!settings.aiApiKey) {
-      throw new Error("Add a DeepSeek API key.");
+
+    function readFallbackValue(key) {
+      try {
+        const rawValue = fallbackStorage?.getItem(
+          `${PREVIEW_STORAGE_PREFIX}${key}`,
+        );
+        if (rawValue !== null && rawValue !== undefined) {
+          return JSON.parse(rawValue);
+        }
+      } catch (_error) {
+        // Fall through to memory when localStorage is unavailable or malformed.
+      }
+      return memoryStorage.get(key);
     }
 
-    await chrome.storage.local.set({
-      [YTD_SETTINGS.STORAGE_KEY]: settings,
-    });
+    function writeFallbackValue(key, value) {
+      memoryStorage.set(key, value);
+      try {
+        fallbackStorage?.setItem(
+          `${PREVIEW_STORAGE_PREFIX}${key}`,
+          JSON.stringify(value),
+        );
+      } catch (_error) {
+        // The in-memory copy keeps a restricted preview functional.
+      }
+    }
 
-    saveStatus.textContent = "Saved. Reopen YouTube Digest to use these settings.";
-  } catch (error) {
-    saveStatus.textContent = error.message;
+    return {
+      async get(keys) {
+        if (chromeStorage) return chromeStorage.get(keys);
+
+        const requestedKeys =
+          keys === null
+            ? [
+                ...new Set([
+                  ...memoryStorage.keys(),
+                  ...fallbackKeys().map((key) =>
+                    key.slice(PREVIEW_STORAGE_PREFIX.length),
+                  ),
+                ]),
+              ]
+            : Array.isArray(keys)
+              ? keys
+              : [keys];
+
+        return Object.fromEntries(
+          requestedKeys
+            .map((key) => [key, readFallbackValue(key)])
+            .filter(([, value]) => value !== undefined),
+        );
+      },
+
+      async set(items) {
+        if (chromeStorage) return chromeStorage.set(items);
+        for (const [key, value] of Object.entries(items)) {
+          writeFallbackValue(key, value);
+        }
+      },
+
+      async remove(keys) {
+        if (chromeStorage) return chromeStorage.remove(keys);
+        for (const key of Array.isArray(keys) ? keys : [keys]) {
+          memoryStorage.delete(key);
+          try {
+            fallbackStorage?.removeItem(`${PREVIEW_STORAGE_PREFIX}${key}`);
+          } catch (_error) {
+            // Memory removal is sufficient for this preview session.
+          }
+        }
+      },
+
+      async clear() {
+        if (chromeStorage) return chromeStorage.clear();
+        memoryStorage.clear();
+        for (const key of fallbackKeys()) {
+          try {
+            fallbackStorage.removeItem(key);
+          } catch (_error) {
+            // Continue clearing any remaining preview keys.
+          }
+        }
+      },
+    };
   }
-}
 
-async function copyCustomizationPrompt() {
-  copyStatus.textContent = "Copying…";
-  try {
-    await navigator.clipboard.writeText(customizationPrompt.value);
-    copyStatus.textContent = "Customization prompt copied.";
-  } catch (_error) {
-    copyStatus.textContent =
-      "Could not copy the prompt. Select the prompt text and copy it manually.";
+  async function readPreferredLanguage(storage) {
+    const stored = await storage.get(LANGUAGE_STORAGE_KEY);
+    return normalizeLanguage(stored[LANGUAGE_STORAGE_KEY]);
   }
+
+  async function persistPreferredLanguage(storage, language) {
+    const normalizedLanguage = normalizeLanguage(language);
+    await storage.set({ [LANGUAGE_STORAGE_KEY]: normalizedLanguage });
+    return normalizedLanguage;
+  }
+
+  function updateLanguageButtonState(buttons, language) {
+    const normalizedLanguage = normalizeLanguage(language);
+    for (const button of buttons) {
+      button.setAttribute(
+        "aria-pressed",
+        String(button.dataset.language === normalizedLanguage),
+      );
+    }
+  }
+
+  function updateLocalizedPrompt(textarea, prompt) {
+    const selectionStart = textarea.selectionStart;
+    const selectionEnd = textarea.selectionEnd;
+    const selectionDirection = textarea.selectionDirection;
+    const scrollTop = textarea.scrollTop;
+    const scrollLeft = textarea.scrollLeft;
+
+    textarea.value = prompt;
+
+    if (
+      Number.isInteger(selectionStart) &&
+      Number.isInteger(selectionEnd) &&
+      typeof textarea.setSelectionRange === "function"
+    ) {
+      textarea.setSelectionRange(
+        Math.min(selectionStart, prompt.length),
+        Math.min(selectionEnd, prompt.length),
+        selectionDirection || "none",
+      );
+    }
+    textarea.scrollTop = scrollTop;
+    textarea.scrollLeft = scrollLeft;
+  }
+
+  function createPromptDrafts() {
+    return {
+      en: translate("en", "customizationPrompt"),
+      "zh-CN": translate("zh-CN", "customizationPrompt"),
+    };
+  }
+
+  function switchPromptDraft(
+    drafts,
+    currentLanguage,
+    nextLanguage,
+    currentValue,
+  ) {
+    const normalizedCurrentLanguage = normalizeLanguage(currentLanguage);
+    const normalizedNextLanguage = normalizeLanguage(nextLanguage);
+    drafts[normalizedCurrentLanguage] = String(currentValue ?? "");
+    if (typeof drafts[normalizedNextLanguage] !== "string") {
+      drafts[normalizedNextLanguage] = translate(
+        normalizedNextLanguage,
+        "customizationPrompt",
+      );
+    }
+    return {
+      language: normalizedNextLanguage,
+      prompt: drafts[normalizedNextLanguage],
+    };
+  }
+
+  async function copyPromptValue(clipboard, value) {
+    await clipboard.writeText(value);
+  }
+
+  function getSafeLocalStorage(root) {
+    try {
+      return root.localStorage;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function initialize(root = globalThis) {
+    const doc = root.document;
+    const settingsApi = root.YTD_SETTINGS;
+    if (!doc || !settingsApi) return;
+
+    const storage = createStorageAdapter(
+      root.chrome,
+      getSafeLocalStorage(root),
+    );
+    const form = doc.getElementById("settingsForm");
+    const aiApiKeyInput = doc.getElementById("aiApiKey");
+    const supadataApiKeyInput = doc.getElementById("supadataApiKey");
+    const customizationPrompt = doc.getElementById("customizationPrompt");
+    const copyCustomizationPromptBtn = doc.getElementById(
+      "copyCustomizationPromptBtn",
+    );
+    const copyStatus = doc.getElementById("copyStatus");
+    const saveStatus = doc.getElementById("saveStatus");
+    const dataStatus = doc.getElementById("dataStatus");
+    const languageButtons = [...doc.querySelectorAll("[data-language]")];
+    const statusStates = new Map();
+    const promptDrafts = createPromptDrafts();
+    let currentLanguage = "en";
+
+    function renderStatus(element) {
+      const state = statusStates.get(element);
+      element.textContent = state
+        ? translate(currentLanguage, state.key, state.params)
+        : "";
+    }
+
+    function setStatus(element, key, params = {}) {
+      statusStates.set(element, { key, params });
+      renderStatus(element);
+    }
+
+    function applyLanguage(language) {
+      const nextDraft = switchPromptDraft(
+        promptDrafts,
+        currentLanguage,
+        language,
+        customizationPrompt.value,
+      );
+      currentLanguage = nextDraft.language;
+      doc.documentElement.lang = currentLanguage;
+      doc.title = translate(currentLanguage, "pageTitle");
+
+      for (const element of doc.querySelectorAll("[data-i18n]")) {
+        element.textContent = translate(
+          currentLanguage,
+          element.dataset.i18n,
+        );
+      }
+      for (const element of doc.querySelectorAll("[data-i18n-html]")) {
+        element.innerHTML = translate(
+          currentLanguage,
+          element.dataset.i18nHtml,
+        );
+      }
+      for (const element of doc.querySelectorAll("[data-i18n-aria-label]")) {
+        element.setAttribute(
+          "aria-label",
+          translate(currentLanguage, element.dataset.i18nAriaLabel),
+        );
+      }
+
+      updateLocalizedPrompt(
+        customizationPrompt,
+        nextDraft.prompt,
+      );
+      updateLanguageButtonState(languageButtons, currentLanguage);
+      for (const element of statusStates.keys()) renderStatus(element);
+    }
+
+    async function loadSettings() {
+      try {
+        const stored = await storage.get(settingsApi.STORAGE_KEY);
+        const migration = settingsApi.migrateLegacyCustom(
+          stored[settingsApi.STORAGE_KEY],
+        );
+        const settings = migration.settings;
+
+        aiApiKeyInput.value = settings.aiApiKey;
+        supadataApiKeyInput.value = settings.supadataApiKey;
+        if (migration.migrated) {
+          await storage.set({ [settingsApi.STORAGE_KEY]: settings });
+          setStatus(saveStatus, "migrationWarning");
+        }
+      } catch (_error) {
+        setStatus(saveStatus, "settingsLoadFailed");
+      }
+    }
+
+    async function loadOptions() {
+      try {
+        applyLanguage(await readPreferredLanguage(storage));
+      } catch (_error) {
+        applyLanguage("en");
+      }
+      await loadSettings();
+    }
+
+    async function saveSettings(event) {
+      event.preventDefault();
+      setStatus(saveStatus, "saving");
+
+      const settings = settingsApi.normalize({
+        aiApiKey: aiApiKeyInput.value,
+        supadataApiKey: supadataApiKeyInput.value,
+      });
+
+      if (!settings.supadataApiKey) {
+        setStatus(saveStatus, "addSupadataKey");
+        return;
+      }
+      if (!settings.aiApiKey) {
+        setStatus(saveStatus, "addDeepseekKey");
+        return;
+      }
+
+      try {
+        await storage.set({ [settingsApi.STORAGE_KEY]: settings });
+        setStatus(saveStatus, "saved");
+      } catch (_error) {
+        setStatus(saveStatus, "saveFailed");
+      }
+    }
+
+    async function copyCustomizationPrompt() {
+      setStatus(copyStatus, "copying");
+      try {
+        await copyPromptValue(
+          root.navigator.clipboard,
+          customizationPrompt.value,
+        );
+        setStatus(copyStatus, "promptCopied");
+      } catch (_error) {
+        setStatus(copyStatus, "copyFailed");
+      }
+    }
+
+    async function clearCachedDigests() {
+      const all = await storage.get(null);
+      const keys = Object.keys(all).filter((key) => key.startsWith("digest_"));
+      if (keys.length) await storage.remove(keys);
+      setStatus(dataStatus, "clearedDigests", { count: keys.length });
+    }
+
+    async function clearNotes() {
+      await storage.remove("ytd_notes");
+      setStatus(dataStatus, "notesDeleted");
+    }
+
+    async function resetAllData() {
+      const confirmed = root.confirm(
+        translate(currentLanguage, "resetConfirm"),
+      );
+      if (!confirmed) return;
+
+      await storage.clear();
+      await persistPreferredLanguage(storage, currentLanguage);
+      await loadSettings();
+      setStatus(dataStatus, "allDataDeleted");
+    }
+
+    form.addEventListener("submit", saveSettings);
+    copyCustomizationPromptBtn.addEventListener(
+      "click",
+      copyCustomizationPrompt,
+    );
+    doc
+      .getElementById("clearCacheBtn")
+      .addEventListener("click", clearCachedDigests);
+    doc.getElementById("clearNotesBtn").addEventListener("click", clearNotes);
+    doc.getElementById("resetBtn").addEventListener("click", resetAllData);
+    for (const button of languageButtons) {
+      button.addEventListener("click", async () => {
+        const language = button.dataset.language;
+        applyLanguage(language);
+        await persistPreferredLanguage(storage, language);
+      });
+    }
+
+    if (doc.readyState === "loading") {
+      doc.addEventListener("DOMContentLoaded", loadOptions, { once: true });
+    } else {
+      void loadOptions();
+    }
+  }
+
+  return {
+    COPY,
+    LANGUAGE_STORAGE_KEY,
+    copyPromptValue,
+    createPromptDrafts,
+    createStorageAdapter,
+    normalizeLanguage,
+    persistPreferredLanguage,
+    readPreferredLanguage,
+    translate,
+    updateLanguageButtonState,
+    updateLocalizedPrompt,
+    switchPromptDraft,
+    initialize,
+  };
+})();
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = YTD_OPTIONS;
 }
 
-async function clearCachedDigests() {
-  const all = await chrome.storage.local.get(null);
-  const keys = Object.keys(all).filter((key) => key.startsWith("digest_"));
-  if (keys.length) await chrome.storage.local.remove(keys);
-  dataStatus.textContent = `Cleared ${keys.length} cached digest${keys.length === 1 ? "" : "s"}.`;
-}
-
-async function clearNotes() {
-  await chrome.storage.local.remove("ytd_notes");
-  dataStatus.textContent = "Deleted all saved notes.";
-}
-
-async function resetAllData() {
-  const confirmed = window.confirm(
-    "Delete API keys, cached digests, translations, and saved notes from this Chrome profile?",
-  );
-  if (!confirmed) return;
-
-  await chrome.storage.local.clear();
-  await loadSettings();
-  dataStatus.textContent = "All YouTube Digest data was deleted.";
+if (typeof document !== "undefined") {
+  YTD_OPTIONS.initialize();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-digest",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "description": "Turn YouTube videos into learning resources with transcripts, bilingual translation, AI overviews, and notes.",
   "license": "MIT",

--- a/tests/options-language.test.js
+++ b/tests/options-language.test.js
@@ -1,0 +1,263 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const options = require("../options.js");
+
+const root = path.resolve(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+
+function createLocalStorage() {
+  const values = new Map();
+  return {
+    get length() {
+      return values.size;
+    },
+    key(index) {
+      return [...values.keys()][index] ?? null;
+    },
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+test("Settings copy covers English and Simplified Chinese", () => {
+  assert.equal(options.translate("en", "pageTitle"), "YouTube Digest Settings");
+  assert.equal(options.translate("zh-CN", "pageTitle"), "YouTube Digest 设置");
+  assert.equal(options.translate("en", "saveSettings"), "Save settings");
+  assert.equal(options.translate("zh-CN", "saveSettings"), "保存设置");
+  assert.equal(
+    options.translate("zh-CN", "clearedDigests", { count: 2 }),
+    "已清除 2 条缓存摘要。",
+  );
+
+  assert.deepEqual(
+    Object.keys(options.COPY.en).sort(),
+    Object.keys(options.COPY["zh-CN"]).sort(),
+  );
+
+  const html = read("options.html");
+  const referencedKeys = [
+    ...html.matchAll(/data-i18n(?:-html|-aria-label)?="([^"]+)"/g),
+  ].map((match) => match[1]);
+  for (const key of referencedKeys) {
+    assert.ok(options.COPY.en[key], `Missing English copy for ${key}`);
+    assert.ok(options.COPY["zh-CN"][key], `Missing Chinese copy for ${key}`);
+  }
+  assert.doesNotMatch(JSON.stringify(options.COPY), /—/);
+  assert.doesNotMatch(html, /—/);
+});
+
+test("language preference persists through extension-compatible storage", async () => {
+  const storedValues = {};
+  const chromeApi = {
+    storage: {
+      local: {
+        async get(key) {
+          return Object.hasOwn(storedValues, key)
+            ? { [key]: storedValues[key] }
+            : {};
+        },
+        async set(items) {
+          Object.assign(storedValues, items);
+        },
+        async remove() {},
+        async clear() {},
+      },
+    },
+  };
+  const storage = options.createStorageAdapter(chromeApi);
+
+  await options.persistPreferredLanguage(storage, "zh-CN");
+
+  assert.equal(storedValues[options.LANGUAGE_STORAGE_KEY], "zh-CN");
+  assert.equal(await options.readPreferredLanguage(storage), "zh-CN");
+});
+
+test("non-extension preview safely persists language in localStorage", async () => {
+  const localStorage = createLocalStorage();
+  const firstSession = options.createStorageAdapter(null, localStorage);
+
+  await options.persistPreferredLanguage(firstSession, "zh-CN");
+
+  const reopenedSession = options.createStorageAdapter(null, localStorage);
+  assert.equal(await options.readPreferredLanguage(reopenedSession), "zh-CN");
+  assert.equal(options.normalizeLanguage("unsupported"), "en");
+});
+
+test("language controls expose a labelled group and one pressed button", () => {
+  const html = read("options.html");
+  assert.match(
+    html,
+    /class="language-switch"[\s\S]*role="group"[\s\S]*aria-label="Interface language"/,
+  );
+  assert.match(
+    html,
+    /data-language="en"[\s\S]*aria-pressed="true"[\s\S]*English/,
+  );
+  assert.match(
+    html,
+    /data-language="zh-CN"[\s\S]*aria-pressed="false"[\s\S]*中文/,
+  );
+
+  const buttons = ["en", "zh-CN"].map((language) => ({
+    dataset: { language },
+    attributes: {},
+    setAttribute(name, value) {
+      this.attributes[name] = value;
+    },
+  }));
+  options.updateLanguageButtonState(buttons, "zh-CN");
+
+  assert.equal(buttons[0].attributes["aria-pressed"], "false");
+  assert.equal(buttons[1].attributes["aria-pressed"], "true");
+});
+
+test("customization guidance is concise and has a visible placeholder reminder", () => {
+  const html = read("options.html");
+  const steps = html.match(
+    /<ol class="customization-steps">([\s\S]*?)<\/ol>/,
+  );
+
+  assert.ok(steps, "Expected a numbered customization guide");
+  assert.equal((steps[1].match(/<li\b/g) || []).length, 3);
+  assert.match(html, /class="prompt-reminder"/);
+  assert.match(html, /role="note"/);
+  assert.equal(
+    options.translate("zh-CN", "customizationReminder"),
+    "复制前，请先把 [PROVIDER] 和 [MODEL] 替换成你想使用的服务和模型。",
+  );
+  assert.equal(
+    options.translate("en", "customizationStepFolder"),
+    "Open the extracted YouTube Digest project folder in your coding agent.",
+  );
+  assert.equal(
+    options.translate("zh-CN", "customizationStepFolder"),
+    "在编程 Agent 中打开 YouTube Digest 解压后的项目文件夹。",
+  );
+  assert.doesNotMatch(html, /~\/Documents\/youtube-digest/);
+  assert.doesNotMatch(html, /%USERPROFILE%\\Documents\\youtube-digest/);
+});
+
+test("customization prompt switches languages and preserves technical values", () => {
+  const html = read("options.html");
+  const englishPrompt = options.translate("en", "customizationPrompt");
+  const chinesePrompt = options.translate("zh-CN", "customizationPrompt");
+
+  assert.match(html, /placeholder="Paste your Supadata key"/);
+  assert.match(html, /placeholder="Paste your DeepSeek key"/);
+  assert.match(html, /https:\/\/dash\.supadata\.ai\/auth\/sign-up/);
+  assert.match(html, /https:\/\/platform\.deepseek\.com\/api_keys/);
+  assert.ok(html.includes(`>${englishPrompt}</textarea>`));
+  assert.match(chinesePrompt, /^请把当前本地 YouTube Digest 工作区改为使用/);
+  assert.notEqual(chinesePrompt, englishPrompt);
+  assert.match(
+    englishPrompt,
+    /Keep DeepSeek-only request fields and retry behavior isolated to DeepSeek\. Handle provider-specific rules separately so one provider does not affect another\./,
+  );
+  assert.match(
+    chinesePrompt,
+    /DeepSeek 专用的请求参数和重试逻辑继续只用于 DeepSeek。新服务的专属规则请单独处理，避免相互影响。/,
+  );
+
+  for (const prompt of [englishPrompt, chinesePrompt]) {
+    assert.match(prompt, /\[PROVIDER\]/);
+    assert.match(prompt, /\[MODEL\]/);
+    assert.match(prompt, /manifest\.json/);
+    assert.match(prompt, /README\.md/);
+    assert.match(prompt, /README\.zh-CN\.md/);
+    assert.match(prompt, /PRIVACY\.md/);
+    assert.match(prompt, /SECURITY\.md/);
+    assert.match(prompt, /npm test/);
+    assert.match(prompt, /npm run check/);
+    assert.match(prompt, /npm run package/);
+    assert.doesNotMatch(prompt, /—/);
+  }
+  const textareaTag = html.match(/<textarea id="customizationPrompt"[^>]*>/);
+  assert.ok(textareaTag, "Expected the customization prompt textarea");
+  assert.doesNotMatch(textareaTag[0], /\sreadonly(?:\s|=|>)/);
+  assert.match(
+    textareaTag[0],
+    /aria-describedby="customizationPromptReminder"/,
+  );
+  assert.doesNotMatch(html, /<textarea id="customizationPrompt"[^>]*data-i18n/);
+});
+
+test("language switching preserves edited prompt drafts for the page session", () => {
+  const drafts = options.createPromptDrafts();
+  const chineseDefault = drafts["zh-CN"];
+
+  const chinese = options.switchPromptDraft(
+    drafts,
+    "en",
+    "zh-CN",
+    "Edited English [PROVIDER] [MODEL]",
+  );
+  assert.equal(chinese.prompt, chineseDefault);
+
+  const english = options.switchPromptDraft(
+    drafts,
+    "zh-CN",
+    "en",
+    "已编辑中文 [PROVIDER] [MODEL]",
+  );
+  assert.equal(english.prompt, "Edited English [PROVIDER] [MODEL]");
+
+  const restoredChinese = options.switchPromptDraft(
+    drafts,
+    "en",
+    "zh-CN",
+    english.prompt,
+  );
+  assert.equal(restoredChinese.prompt, "已编辑中文 [PROVIDER] [MODEL]");
+});
+
+test("copy helper writes the current edited textarea value", async () => {
+  const writes = [];
+  const clipboard = {
+    async writeText(value) {
+      writes.push(value);
+    },
+  };
+
+  await options.copyPromptValue(
+    clipboard,
+    "My edited prompt for [PROVIDER] and [MODEL]",
+  );
+
+  assert.deepEqual(writes, ["My edited prompt for [PROVIDER] and [MODEL]"]);
+});
+
+test("localized prompt updates preserve the textarea selection and scroll", () => {
+  const textarea = {
+    value: options.translate("en", "customizationPrompt"),
+    selectionStart: 12,
+    selectionEnd: 48,
+    selectionDirection: "forward",
+    scrollTop: 90,
+    scrollLeft: 7,
+    setSelectionRange(start, end, direction) {
+      this.selectionStart = start;
+      this.selectionEnd = end;
+      this.selectionDirection = direction;
+    },
+  };
+  const chinesePrompt = options.translate("zh-CN", "customizationPrompt");
+
+  options.updateLocalizedPrompt(textarea, chinesePrompt);
+
+  assert.equal(textarea.value, chinesePrompt);
+  assert.equal(textarea.selectionStart, 12);
+  assert.equal(textarea.selectionEnd, 48);
+  assert.equal(textarea.selectionDirection, "forward");
+  assert.equal(textarea.scrollTop, 90);
+  assert.equal(textarea.scrollLeft, 7);
+});

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -17,7 +17,7 @@ test("manifest uses minimized install-time permissions", () => {
   assert.ok(!manifest.permissions.includes("activeTab"));
   assert.ok(manifest.host_permissions.includes("https://api.deepseek.com/*"));
   assert.equal(Object.hasOwn(manifest, "optional_host_permissions"), false);
-  assert.equal(manifest.version, "1.1.4");
+  assert.equal(manifest.version, "1.1.5");
 });
 
 test("release copy documents current scope without em dashes", () => {
@@ -132,25 +132,27 @@ test("release copy documents current scope without em dashes", () => {
   assert.doesNotMatch(detailsTag[0], /\sopen(?:\s|=|>)/i);
   assert.match(
     optionsPage,
-    /<summary class="customization-summary">[\s\S]*Want to use another AI model\?[\s\S]*Copy a safe prompt for your coding agent[\s\S]*<\/summary>/,
+    /<summary class="customization-summary">[\s\S]*Want to use another AI model\?[\s\S]*Edit and copy a safe prompt for your coding agent[\s\S]*<\/summary>/,
   );
   assert.match(
     optionsPage,
-    /Before copying, open the[\s\S]*exact YouTube Digest project folder that Chrome loaded through[\s\S]*Load unpacked[\s\S]*For a first-time installation, optional permanent[\s\S]*~\/Documents\/youtube-digest[\s\S]*%USERPROFILE%\\Documents\\youtube-digest[\s\S]*suggestions, not assumed paths/,
+    /class="customization-steps"[\s\S]*Open the extracted YouTube Digest project folder in your coding[\s\S]*Replace \[PROVIDER\] and \[MODEL\][\s\S]*Never include API keys[\s\S]*<\/ol>/,
   );
   assert.match(
     optionsPage,
-    /Chrome and the extension[\s\S]*cannot reliably reveal or copy the actual OS path/,
+    /class="prompt-reminder"[\s\S]*Before copying, replace \[PROVIDER\] and \[MODEL\]/,
   );
+  assert.doesNotMatch(optionsPage, /~\/Documents\/youtube-digest/);
+  assert.doesNotMatch(optionsPage, /%USERPROFILE%\\Documents\\youtube-digest/);
   assert.match(optionsPage, /id="copyCustomizationPromptBtn"/);
   assert.match(optionsStyles, /\.customization-summary:hover\s*\{/);
   assert.match(optionsStyles, /\.customization-summary:focus-visible\s*\{/);
   assert.match(optionsStyles, /\.data-card\s*\{[^}]*margin-top:\s*36px;/);
-  assert.match(optionsScript, /navigator\.clipboard\.writeText/);
-  assert.match(optionsScript, /Customization prompt copied\./);
-  assert.match(optionsScript, /migration\.migrated[\s\S]*chrome\.storage\.local\.set/);
+  assert.match(optionsScript, /clipboard\.writeText/);
+  assert.match(optionsScript, /Edited prompt copied\./);
+  assert.match(optionsScript, /migration\.migrated[\s\S]*storage\.set/);
 
-  const customizationPrompt = `Customize my local copy of YouTube Digest to use [PROVIDER] with [MODEL]. Work only in the currently open workspace. Before editing anything, verify that this workspace contains manifest.json and that its name is YouTube Digest. If verification fails, stop and tell me: "Open the exact YouTube Digest project folder that Chrome loaded through Load unpacked in your coding agent, then paste this prompt again." Do not search other folders or the whole disk, edit a guessed copy, assume an installation path, or claim that Chrome or the extension can reveal the absolute OS source path. Update the API endpoint, request format, and minimum Chrome host permissions needed for that provider. Preserve the bring-your-own-key model and local Chrome storage. Keep all API keys out of source code, commits, logs, screenshots, and this chat; after the code is ready, tell me where I should enter the key myself. Keep DeepSeek-specific fields and retries provider-scoped, update README.md, README.zh-CN.md, PRIVACY.md, SECURITY.md, and the tests, then run npm test, npm run check, and npm run package. Finally, explain how to reload the unpacked extension and test it on a real YouTube video.`;
+  const customizationPrompt = `Customize this local YouTube Digest workspace to use [PROVIDER] with [MODEL]. Work only in the current workspace. Before editing, verify that it contains manifest.json and that the manifest name is YouTube Digest. If verification fails, stop and ask me to open the extracted YouTube Digest project folder in my coding agent. Do not search other folders, edit a guessed copy, assume an installation path, or claim Chrome can reveal the absolute OS source path. Update the provider's API endpoint, request format, and minimum Chrome host permissions. Preserve bring-your-own-key and local Chrome storage. Never put API keys in source code, commits, logs, screenshots, this prompt, or chat; after the code is ready, tell me where to enter the key myself. Keep DeepSeek-only request fields and retry behavior isolated to DeepSeek. Handle provider-specific rules separately so one provider does not affect another. Update README.md, README.zh-CN.md, PRIVACY.md, SECURITY.md, and tests. Run npm test, npm run check, and npm run package. Then explain how to reload the unpacked extension and test it on a real YouTube video.`;
   assert.ok(optionsPage.includes(`>${customizationPrompt}</textarea>`));
   assert.doesNotMatch(customizationPrompt, /Documents|USERPROFILE/);
 


### PR DESCRIPTION
## What changed

- add an accessible English and Simplified Chinese toggle to Settings
- persist the selected interface language locally
- localize all Settings labels, helper text, status messages, and confirmation copy
- provide editable English and Chinese coding-agent prompts
- preserve per-language prompt drafts while switching languages
- simplify the remix guide and clarify placeholder and API-key safety
- bump the extension and package version to 1.1.5

## User impact

Chinese-speaking users can configure the extension in Chinese and directly personalize the coding-agent prompt before copying it. English remains the default.

## Validation

- `npm test` with 42/42 passing
- `npm run check`
- `npm run package`
- `git diff --check`
- manual Chrome preview in both languages, including editable draft restoration

Package: `dist/youtube-digest-v1.1.5.zip`

SHA-256: `f15ff0f50e8e58301b70e181a89dffeceea8b3a1a3447fd232100279362ffa28`