### PR TITLE
Fetch transcripts locally with optional Supadata fallback

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,7 +22,7 @@ Depending on the feature you use, YouTube Digest handles:
 
 ### Supadata
 
-YouTube Digest sends the canonical YouTube video URL to `https://api.supadata.ai` with your Supadata API key. Supadata returns the transcript and timestamps. A Supadata key is required for transcript retrieval.
+YouTube Digest first tries to read caption tracks from the active YouTube page's own player state and fetch the subtitles from YouTube's timedtext endpoint. This local path involves no Supadata request. Only when local extraction fails does it send the canonical YouTube video URL to `https://api.supadata.ai` with your Supadata API key, and Supadata returns the transcript and timestamps. A Supadata key is optional: without one, the extension simply reports that captions could not be extracted.
 
 ### DeepSeek
 
@@ -36,7 +36,7 @@ The published version sends AI feature content to DeepSeek V4 Flash at `https://
 
 The endpoint and `deepseek-v4-flash` model are fixed in the published Settings page. You provide one DeepSeek API key. To use another provider or model, you must adapt your own local source copy and its permissions. The Settings page provides a coding-agent prompt for that purpose and warns you never to include an API key in the prompt or chat.
 
-Requests go directly from the extension to Supadata or DeepSeek. They are authenticated with the keys you supply. YouTube Digest's developer does not proxy or receive these requests.
+Requests go directly from the extension to YouTube, Supadata, or DeepSeek. The timedtext request to YouTube uses a track URL already present in the page's player state. All requests are authenticated only where a key applies, with the keys you supply. YouTube Digest's developer does not proxy or receive these requests.
 
 Those services process data under their own terms, privacy policies, retention practices, and account settings. Do not send confidential, personal, or regulated content unless their terms and your obligations permit it.
 
@@ -69,8 +69,8 @@ YouTube Digest uses Chrome permissions for these purposes:
 - `storage`: store settings, keys, notes, and cached results locally.
 - `tabs`: identify and interact with the active YouTube tab.
 - `scripting`: coordinate the extension's YouTube page controls.
-- YouTube host access: read the active video's URL and metadata and provide timestamp controls.
-- Supadata host access: retrieve transcripts.
+- YouTube host access: read the active video's URL, metadata, and page player state, and fetch caption tracks from YouTube's timedtext endpoint.
+- Supadata host access: retrieve transcripts when local extraction fails.
 - DeepSeek host access: provide AI overviews, explanations, translation, and note polishing through DeepSeek V4 Flash.
 
 YouTube Digest does not use these permissions to monitor general browsing activity.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You do not need to understand the code or use the command line. Send this messag
 Your agent should:
 
 1. Ask where you want to keep the project, download or clone it there, and tell you the exact full path. If you want a suggestion, it can offer `~/Documents/youtube-digest` on macOS or Linux, or `%USERPROFILE%\Documents\youtube-digest` on Windows.
-2. Open the official Supadata and DeepSeek pages below and help you create your own accounts.
+2. Open the official DeepSeek page below and help me create my own account. A Supadata account is optional, the extension extracts captions from the YouTube page locally and only falls back to Supadata when that fails.
 3. Walk you through selecting the exact project folder you chose in Chrome with **Load unpacked**.
 4. Show you where to enter your API keys in the extension's **Settings** page.
 5. Open a YouTube video with captions and confirm the transcript and translation work.
@@ -48,12 +48,13 @@ Because this is an unpacked extension, it does not update automatically. After d
 
 ## Set up your API keys
 
-YouTube Digest needs two keys under your own provider accounts:
+YouTube Digest needs a **DeepSeek API key** for overviews, explanations, translation, and automatic note polishing. A **Supadata API key is optional**: captions are extracted directly from the YouTube page in your browser, and Supadata is only used as a fallback when local extraction fails.
 
-1. A **Supadata API key** to retrieve YouTube transcripts.
-2. A **DeepSeek API key** for overviews, explanations, translation, and automatic note polishing.
+### How transcripts are fetched
 
-### Get a Supadata API key
+YouTube Digest reads the caption tracks from the YouTube page's own player state and fetches the subtitles from YouTube's timedtext endpoint, the same data the player shows with captions on. This needs no API key and uses no credits. If that fails, it falls back to the Supadata API (below).
+
+### Get a Supadata API key (optional fallback)
 
 1. Open the official [Supadata sign-up page](https://dash.supadata.ai/auth/sign-up).
 2. Create an account and complete the short onboarding flow.
@@ -100,7 +101,7 @@ Keys and settings are stored in Chrome's local extension storage on your device.
 
 - Google Chrome 116 or newer, using the Side Panel API.
 - Standard `youtube.com/watch` video pages.
-- Native subtitle tracks returned by Supadata. YouTube Digest prefers English when available, but may show another native language.
+- Native subtitle tracks from the page itself, or from Supadata when local extraction fails. YouTube Digest prefers English when available, but may show another native language.
 - Original, Simplified Chinese, and aligned bilingual transcript views.
 - AI overviews, selected-text explanations, translation, and automatic note polishing.
 - Local notes and a local cache for recent transcript and digest results.
@@ -108,11 +109,11 @@ Keys and settings are stored in Chrome's local extension storage on your device.
 
 Shorts, live streams, private or access-restricted videos, and videos without an available native transcript may not work. Firefox, Safari, mobile browsers, and other Chromium browsers are not currently tested or supported.
 
-YouTube Digest forces Supadata's `mode=native`. It does not request AI-generated transcripts or perform local audio transcription when native captions are unavailable.
+YouTube Digest fetches native captions only. It never requests AI-generated transcripts or performs local audio transcription when native captions are unavailable. The Supadata fallback forces `mode=native` for the same reason.
 
 ## Supadata free tier and request costs
 
-Current as of August 9, 2026, the [Supadata pricing page](https://supadata.ai/pricing) lists a free tier with **100 credits per month**, no credit card required. Unused credits do not roll over. Supadata pricing can change, so check the current page before relying on these numbers.
+Local extraction means Supadata is not called for most videos, so the free tier usually covers plenty of fallback lookups. Current as of August 9, 2026, the [Supadata pricing page](https://supadata.ai/pricing) lists a free tier with **100 credits per month**, no credit card required. Unused credits do not roll over. Supadata pricing can change, so check the current page before relying on these numbers.
 
 The [Supadata transcript documentation](https://docs.supadata.ai/get-transcript) describes the transcript request modes and credit behavior:
 
@@ -162,7 +163,7 @@ If you want another AI provider or model, first open the exact YouTube Digest pr
 
 YouTube Digest makes provider requests directly from the extension:
 
-1. It sends a canonical YouTube watch URL to Supadata to request the native transcript.
+1. It reads the caption tracks from the YouTube page and fetches the subtitles from YouTube's timedtext endpoint in your browser. Only when that fails does it send a canonical YouTube watch URL to Supadata to request the native transcript.
 2. It sends the transcript and relevant video metadata to DeepSeek when you request AI features.
 3. Focused features send only the content they need, such as selected text with context or small transcript batches for translation.
 4. It stores keys, settings, notes, and recent cache entries locally in Chrome.
@@ -188,14 +189,14 @@ There is no YouTube Digest account system, advertising, analytics, or telemetry.
 
 ### YouTube Digest asks for setup
 
-- Open **Settings** and save both a Supadata key and a DeepSeek key.
+- Open **Settings** and save a DeepSeek key. A Supadata key is optional, captions are extracted from the YouTube page locally first.
 - This published version uses the fixed DeepSeek V4 Flash endpoint and model. There are no Base URL or Model fields to configure.
 - If Settings says a legacy custom provider was removed, enter a DeepSeek key. The old AI key was cleared so it could not be reused with the wrong service.
 
 ### No transcript is found
 
 - Confirm the video is public and has native captions.
-- Check your Supadata key, remaining credits, rate limit, and account status.
+- If you are relying on the Supadata fallback, check your Supadata key, remaining credits, rate limit, and account status.
 - Remember that unavailable native lookups and manual retries may still consume credits.
 
 YouTube Digest will not fall back to generated transcription.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@ YouTube Digest 是一个需要自行提供 API Key 的开源项目，通过 GitH
 你的 Agent 应该帮你：
 
 1. 先询问你想把项目长期保存在哪里，再下载或克隆到那里，并告诉你准确的完整路径。如果你需要建议，可以推荐 macOS 或 Linux 上的 `~/Documents/youtube-digest`，或 Windows 上的 `%USERPROFILE%\Documents\youtube-digest`。
-2. 打开下方 Supadata 和 DeepSeek 官方页面，指导你创建自己的账号。
+2. 打开下方 DeepSeek 官方页面，指导你创建自己的账号。Supadata 账号可选，扩展会先从 YouTube 页面本地提取字幕，只有失败时才会用 Supadata 兜底。
 3. 指导你在 Chrome 中通过“加载已解压的扩展程序”选择你刚才确定的那个准确项目文件夹。
 4. 告诉你应该在扩展的“设置”页面哪个位置填写 API Key。
 5. 打开一个带字幕的 YouTube 视频，确认字幕和翻译功能可以使用。
@@ -48,12 +48,13 @@ YouTube Digest 是一个需要自行提供 API Key 的开源项目，通过 GitH
 
 ## 设置 API Key
 
-YouTube Digest 需要你在自己的服务账号中准备两个 Key：
+YouTube Digest 需要一个 **DeepSeek API Key**，用于生成概览、讲解内容、翻译和自动润色笔记。**Supadata API Key 是可选的**：字幕会直接从浏览器中的 YouTube 页面提取，只有本地提取失败时才会使用 Supadata 兜底。
 
-1. **Supadata API Key**，用于获取 YouTube 字幕。
-2. **DeepSeek API Key**，用于生成概览、讲解内容、翻译和自动润色笔记。
+### 字幕是如何获取的
 
-### 获取 Supadata API Key
+YouTube Digest 会读取 YouTube 页面自身播放器状态中的字幕轨道，并从 YouTube 的 timedtext 接口获取字幕，与播放器开启字幕时显示的是同一份数据。这个过程不需要 API Key，也不消耗积分。如果失败，才会回退到 Supadata API。
+
+### 获取 Supadata API Key（可选兜底）
 
 1. 打开 Supadata 官方[注册页面](https://dash.supadata.ai/auth/sign-up)。
 2. 创建账号并完成简短的新手引导。
@@ -100,7 +101,7 @@ API Key 和设置保存在你设备上的 Chrome 扩展本地存储中。发布�
 
 - Chrome 116 或更高版本。
 - 标准的 `youtube.com/watch` 视频页面。
-- Supadata 能够返回的原生字幕。YouTube Digest 会优先请求英文字幕，也可能显示其他可用的原生语言。
+- Supadata 能够返回的原生字幕，以及从页面本地提取的原生字幕。YouTube Digest 会优先请求英文字幕，也可能显示其他可用的原生语言。
 - 原文、简体中文和双语对照字幕。
 - AI 概览、选中文本讲解、翻译和自动润色笔记。
 - 本地笔记，以及最近字幕、概览和翻译的本地缓存。
@@ -108,11 +109,11 @@ API Key 和设置保存在你设备上的 Chrome 扩展本地存储中。发布�
 
 Shorts、直播、私密视频、受访问限制的视频，以及没有原生字幕的视频可能无法使用。目前没有测试 Firefox、Safari、移动浏览器或其他 Chromium 浏览器。
 
-YouTube Digest 强制使用 Supadata 的 `mode=native`，不会在没有原生字幕时请求 AI 生成转录，也不会在本地转录音频。
+YouTube Digest 只获取原生字幕，不会在没有原生字幕时请求 AI 生成转录，也不会在本地转录音频。Supadata 兜底路径同样强制使用 `mode=native`。
 
 ## Supadata 免费额度和请求成本
 
-截至 2026 年 8 月 9 日，[Supadata 价格页面](https://supadata.ai/pricing)显示免费版每月提供 **100 credits**，不需要信用卡，未使用的额度不会结转。价格可能变化，使用前请查看最新页面。
+本地提取意味着大多数视频不会调用 Supadata，免费版通常足够覆盖兜底查询。截至 2026 年 8 月 9 日，[Supadata 价格页面](https://supadata.ai/pricing)显示免费版每月提供 **100 credits**，不需要信用卡，未使用的额度不会结转。价格可能变化，使用前请查看最新页面。
 
 [Supadata 字幕接口文档](https://docs.supadata.ai/get-transcript)说明了不同模式的计费方式：
 
@@ -162,7 +163,7 @@ YouTube Digest 使用原生 HTML、CSS 和 JavaScript，没有构建步骤，很
 
 YouTube Digest 会直接从扩展向服务商发送请求：
 
-1. 把标准化的 YouTube 视频地址发送给 Supadata，用于获取原生字幕。
+1. 从 YouTube 页面读取字幕轨道，并在浏览器中从 YouTube 的 timedtext 接口获取字幕。只有本地提取失败时，才把标准化的 YouTube 视频地址发送给 Supadata 获取原生字幕。
 2. 当你使用 AI 功能时，把字幕和相关视频信息发送给 DeepSeek。
 3. 翻译或讲解等功能只发送当前需要的内容，例如选中的文本和上下文，或少量字幕分段。
 4. API Key、设置、笔记和最近缓存保存在 Chrome 本地。
@@ -188,14 +189,14 @@ YouTube Digest 没有账号系统、广告、分析统计或行为追踪。Supad
 
 ### YouTube Digest 提示需要设置
 
-- 打开 **Settings**，保存 Supadata Key 和 DeepSeek Key。
+- 打开 **Settings**，保存 DeepSeek Key。Supadata Key 是可选的，字幕会先从 YouTube 页面本地提取。
 - 发布版本固定使用 DeepSeek V4 Flash，没有需要填写的 Base URL 或 Model 字段。
 - 如果设置提示旧的自定义服务已移除，请重新填写 DeepSeek Key。旧 AI Key 已安全清除，避免被错误用于 DeepSeek。
 
 ### 找不到字幕
 
 - 确认视频是公开的，并且有原生字幕。
-- 检查 Supadata Key、剩余额度、限速和账号状态。
+- 如果依赖 Supadata 兜底，请检查 Supadata Key、剩余额度、限速和账号状态。
 - 没有字幕的查询和手动重试也可能消耗额度。
 
 YouTube Digest 不会自动改用 AI 生成字幕。

--- a/background.js
+++ b/background.js
@@ -302,7 +302,7 @@ chrome.tabs.onActivated.addListener(async ({ tabId }) => {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // We need to return true to indicate we'll respond asynchronously
   if (message.action === "fetchTranscript") {
-    handleFetchTranscript(message.videoId)
+    handleFetchTranscriptLocalFirst(message.videoId, message.tabId)
       .then(sendResponse)
       .catch((err) => sendResponse({ error: err.message }));
     return true; // Keep the message channel open for async response
@@ -341,6 +341,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       message.timestamp,
       message.videoTitle,
       message.channelName,
+      sender.tab?.id,
     )
       .then(sendResponse)
       .catch((err) => sendResponse({ success: false, error: err.message }));
@@ -574,6 +575,298 @@ async function getPlayerVideoDetails(tabId) {
 }
 
 // ============================================================
+// LOCAL TRANSCRIPT EXTRACTION (SUPADATA FALLBACK)
+// ============================================================
+
+const LOCAL_TRANSCRIPT_TIMEOUT_MS = 15_000;
+
+/**
+ * Converts caption chunks (Supadata or local timedtext) into the shared
+ * transcript format used by the side panel and AI features.
+ *
+ * @param {Array<{text: string, offset: number, duration: number, lang?: string}>} chunks
+ * @param {string|null} language - Fallback language for chunks without one
+ * @returns {Object|null} - { success, transcript, transcriptText,
+ *   transcriptTextTimestamped, language } or null when no usable text remains
+ */
+function buildTranscriptResult(chunks, language) {
+  const transcript = [];
+  let transcriptTextPlain = ""; // Plain text for display/export
+  let transcriptTextTimestamped = ""; // Timestamped text for AI analysis
+
+  for (const chunk of chunks) {
+    if (chunk.text) {
+      // Clean up caption artifacts:
+      // ">>" = speaker change marker from YouTube auto-captions
+      const cleanText = chunk.text.replace(/>> ?/g, "").trim();
+      if (!cleanText) continue; // Skip if nothing left after cleanup
+
+      // offset is in milliseconds, convert to seconds
+      const startSeconds = Math.floor((chunk.offset || 0) / 1000);
+      const minutes = Math.floor(startSeconds / 60);
+      const seconds = startSeconds % 60;
+      const timestamp = `${minutes}:${String(seconds).padStart(2, "0")}`;
+
+      transcript.push({
+        text: cleanText,
+        start: startSeconds,
+        duration: Math.floor((chunk.duration || 0) / 1000),
+        language: chunk.lang || language || null,
+      });
+
+      // Plain text without timestamps (for display/export)
+      transcriptTextPlain += cleanText + " ";
+
+      // Timestamped text for DeepSeek (format: [MM:SS] text)
+      // This allows the model to reference actual transcript positions.
+      transcriptTextTimestamped += `[${timestamp}] ${cleanText}\n`;
+    }
+  }
+
+  if (transcript.length === 0) return null;
+
+  return {
+    success: true,
+    transcript: transcript,
+    transcriptText: transcriptTextPlain.trim(), // For display
+    transcriptTextTimestamped: transcriptTextTimestamped.trim(), // For AI
+    language: typeof language === "string" ? language : null,
+  };
+}
+
+/**
+ * Reads the native caption track list from the YouTube tab's player state.
+ *
+ * Runs in the page's MAIN world via chrome.scripting, mirroring the existing
+ * getPlayerVideoDetails pattern. YouTube embeds the same caption data that
+ * Supadata returns: the player response contains a playerCaptionsTracklistRenderer
+ * whose captionTracks point at YouTube's own timedtext endpoint, which needs
+ * no API key.
+ *
+ * Sources, in order: the live player response, the page-global
+ * ytInitialPlayerResponse, then inline <script> JSON as a last resort.
+ *
+ * @param {number} tabId
+ * @returns {Promise<Array<{baseUrl: string, languageCode: string}>|null>}
+ */
+async function readCaptionTracksFromTab(tabId) {
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      func: () => {
+        try {
+          let playerResponse =
+            document.getElementById("movie_player")?.getPlayerResponse?.() ||
+            null;
+
+          if (!playerResponse?.captions?.playerCaptionsTracklistRenderer) {
+            const globalResponse = window.ytInitialPlayerResponse;
+            if (globalResponse?.captions?.playerCaptionsTracklistRenderer) {
+              playerResponse = globalResponse;
+            }
+          }
+
+          if (!playerResponse?.captions?.playerCaptionsTracklistRenderer) {
+            const marker = "var ytInitialPlayerResponse = ";
+            for (const script of document.querySelectorAll("script")) {
+              const text = script.textContent || "";
+              const index = text.indexOf(marker);
+              if (index === -1) continue;
+              const start = index + marker.length;
+              const end = text.indexOf(";", start);
+              if (end === -1) continue;
+              try {
+                const parsed = JSON.parse(text.slice(start, end));
+                if (parsed?.captions?.playerCaptionsTracklistRenderer) {
+                  playerResponse = parsed;
+                  break;
+                }
+              } catch (e) {
+                // Malformed inline JSON — keep looking.
+              }
+            }
+          }
+
+          const tracks =
+            playerResponse?.captions?.playerCaptionsTracklistRenderer
+              ?.captionTracks;
+          if (!Array.isArray(tracks) || tracks.length === 0) return null;
+
+          return tracks
+            .filter((track) => typeof track.baseUrl === "string" && track.baseUrl)
+            .map((track) => ({
+              baseUrl: track.baseUrl,
+              languageCode: track.languageCode || "",
+            }));
+        } catch (e) {
+          return null;
+        }
+      },
+    });
+    return results?.[0]?.result || null;
+  } catch (e) {
+    debugLog("[YouTube Digest BG] Caption tracks unavailable:", e.message);
+    return null;
+  }
+}
+
+/**
+ * Picks the caption track closest to the current English preference,
+ * matching the `lang=en` behavior of the Supadata path.
+ *
+ * @param {Array<{baseUrl: string, languageCode: string}>} tracks
+ * @returns {{baseUrl: string, languageCode: string}|null}
+ */
+function pickCaptionTrack(tracks) {
+  if (!Array.isArray(tracks) || tracks.length === 0) return null;
+  const exact = tracks.find((track) => track.languageCode === "en");
+  if (exact) return exact;
+  const english = tracks.find((track) => track.languageCode.startsWith("en"));
+  if (english) return english;
+  return tracks[0];
+}
+
+/**
+ * Parses the timedtext fmt=json3 response into caption chunks.
+ *
+ * Each event carries tStartMs (ms), optional dDurationMs, and segs with utf8
+ * text pieces that must be joined before normalization.
+ *
+ * @param {Object} json3
+ * @param {string|null} language
+ * @returns {Array<{text: string, offset: number, duration: number, lang: string|null}>}
+ */
+function parseTimedtextJson3(json3, language) {
+  const chunks = [];
+  if (!json3 || !Array.isArray(json3.events)) return chunks;
+
+  for (const event of json3.events) {
+    if (!event || !Array.isArray(event.segs)) continue;
+    let text = "";
+    for (const seg of event.segs) {
+      if (seg && typeof seg.utf8 === "string") text += seg.utf8;
+    }
+    text = text.replace(/\n/g, " ").trim();
+    if (!text) continue;
+
+    chunks.push({
+      text: text,
+      offset: typeof event.tStartMs === "number" ? event.tStartMs : 0,
+      duration:
+        typeof event.dDurationMs === "number" ? event.dDurationMs : 0,
+      lang: language,
+    });
+  }
+  return chunks;
+}
+
+/**
+ * Fetches the transcript directly from YouTube's timedtext endpoint.
+ *
+ * The track baseUrl comes from the page's own player state, so it is already
+ * signed and needs no API key. Runs from the service worker using the
+ * existing youtube.com host permission.
+ *
+ * @param {string} videoId
+ * @param {string} baseUrl
+ * @param {string} language
+ * @returns {Promise<Object|null>} buildTranscriptResult output or null on failure
+ */
+async function fetchTimedtextTranscript(videoId, baseUrl, language) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    LOCAL_TRANSCRIPT_TIMEOUT_MS,
+  );
+
+  try {
+    const timedtextUrl = new URL(baseUrl);
+    timedtextUrl.searchParams.set("fmt", "json3");
+
+    const response = await fetch(timedtextUrl.toString(), {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      debugLog(
+        `[YouTube Digest BG] timedtext request failed: ${response.status}`,
+      );
+      return null;
+    }
+
+    const data = await response.json();
+    const chunks = parseTimedtextJson3(data, language);
+    if (chunks.length === 0) return null;
+    return buildTranscriptResult(chunks, language);
+  } catch (e) {
+    debugLog("[YouTube Digest BG] timedtext fetch failed:", e.message);
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Tries to extract the transcript locally from the YouTube tab, returning
+ * null on any failure so callers fall back to Supadata.
+ *
+ * @param {number} tabId
+ * @param {string} videoId
+ * @returns {Promise<Object|null>}
+ */
+async function tryLocalTranscript(tabId, videoId) {
+  const tracks = await readCaptionTracksFromTab(tabId);
+  if (!tracks) return null;
+
+  const track = pickCaptionTrack(tracks);
+  if (!track) return null;
+
+  return await fetchTimedtextTranscript(
+    videoId,
+    track.baseUrl,
+    track.languageCode || null,
+  );
+}
+
+/**
+ * Transcript fetch orchestration: local extraction first, Supadata fallback.
+ *
+ * Local extraction is free and needs no key, but can fail when YouTube
+ * changes its page internals or when captions require a session the tab does
+ * not have. The result is tagged with its source for debugging.
+ *
+ * @param {string} videoId
+ * @param {number|null} tabId - YouTube tab to extract from; null skips local
+ * @returns {Promise<Object>}
+ */
+async function handleFetchTranscriptLocalFirst(videoId, tabId) {
+  if (tabId) {
+    const local = await tryLocalTranscript(tabId, videoId);
+    if (local?.success) {
+      debugLog("[YouTube Digest BG] Transcript extracted locally:", videoId);
+      return { ...local, source: "local" };
+    }
+    debugLog("[YouTube Digest BG] Local extraction failed, using Supadata");
+  }
+
+  const remote = await handleFetchTranscript(videoId);
+  if (remote.success) return { ...remote, source: "supadata" };
+
+  // Local extraction was attempted but failed, and there is no Supadata key
+  // to fall back on. Explain both facts instead of only asking for a key.
+  if (tabId && remote.error === "NO_SUPADATA_KEY") {
+    return {
+      success: false,
+      error: "NO_TRANSCRIPT",
+      message:
+        "Could not extract captions from this page. Add a Supadata API key in YouTube Digest Settings to use it as a fallback.",
+    };
+  }
+
+  return remote;
+}
+
+// ============================================================
 // TRANSCRIPT FETCHING VIA SUPADATA API
 // ============================================================
 
@@ -667,42 +960,7 @@ async function handleFetchTranscript(videoId) {
 
     // Parse the response into our internal format
     // Supadata returns: { content: [{ text, offset, duration, lang }], lang, availableLangs }
-    const transcript = [];
-    let transcriptTextPlain = ""; // Plain text for display/export
-    let transcriptTextTimestamped = ""; // Timestamped text for AI analysis
-
-    if (data.content && Array.isArray(data.content)) {
-      for (const chunk of data.content) {
-        if (chunk.text) {
-          // Clean up caption artifacts:
-          // ">>" = speaker change marker from YouTube auto-captions
-          const cleanText = chunk.text.replace(/>> ?/g, "").trim();
-          if (!cleanText) continue; // Skip if nothing left after cleanup
-
-          // offset is in milliseconds, convert to seconds
-          const startSeconds = Math.floor((chunk.offset || 0) / 1000);
-          const minutes = Math.floor(startSeconds / 60);
-          const seconds = startSeconds % 60;
-          const timestamp = `${minutes}:${String(seconds).padStart(2, "0")}`;
-
-          transcript.push({
-            text: cleanText,
-            start: startSeconds,
-            duration: Math.floor((chunk.duration || 0) / 1000),
-            language: chunk.lang || data.lang || null,
-          });
-
-          // Plain text without timestamps (for display/export)
-          transcriptTextPlain += cleanText + " ";
-
-          // Timestamped text for DeepSeek (format: [MM:SS] text)
-          // This allows the model to reference actual transcript positions.
-          transcriptTextTimestamped += `[${timestamp}] ${cleanText}\n`;
-        }
-      }
-    }
-
-    if (transcript.length === 0) {
+    if (!data.content || !Array.isArray(data.content)) {
       return {
         success: false,
         error: "EMPTY_TRANSCRIPT",
@@ -710,13 +968,13 @@ async function handleFetchTranscript(videoId) {
       };
     }
 
-    return {
-      success: true,
-      transcript: transcript,
-      transcriptText: transcriptTextPlain.trim(), // For display
-      transcriptTextTimestamped: transcriptTextTimestamped.trim(), // For AI
-      language: typeof data.lang === "string" ? data.lang : null,
-    };
+    return (
+      buildTranscriptResult(data.content, data.lang) || {
+        success: false,
+        error: "EMPTY_TRANSCRIPT",
+        message: "Supadata returned an empty transcript for this video.",
+      }
+    );
   } catch (error) {
     console.error("Transcript fetch error:", error);
     return {
@@ -755,42 +1013,14 @@ async function pollTranscriptJob(jobId, supadataApiKey) {
     const data = await response.json();
 
     if (data.status === "completed") {
-      // Parse the completed transcript
-      const transcript = [];
-      let transcriptTextPlain = "";
-      let transcriptTextTimestamped = "";
-
-      if (data.content && Array.isArray(data.content)) {
-        for (const chunk of data.content) {
-          if (chunk.text) {
-            // Clean up caption artifacts (">>" = speaker change marker)
-            const cleanText = chunk.text.replace(/>> ?/g, "").trim();
-            if (!cleanText) continue;
-
-            const startSeconds = Math.floor((chunk.offset || 0) / 1000);
-            const minutes = Math.floor(startSeconds / 60);
-            const seconds = startSeconds % 60;
-            const timestamp = `${minutes}:${String(seconds).padStart(2, "0")}`;
-
-            transcript.push({
-              text: cleanText,
-              start: startSeconds,
-              duration: Math.floor((chunk.duration || 0) / 1000),
-              language: chunk.lang || data.lang || null,
-            });
-            transcriptTextPlain += cleanText + " ";
-            transcriptTextTimestamped += `[${timestamp}] ${chunk.text}\n`;
-          }
-        }
+      if (!data.content || !Array.isArray(data.content)) {
+        return {
+          success: false,
+          error: "EMPTY_TRANSCRIPT",
+          message: "Supadata returned an empty transcript for this video.",
+        };
       }
-
-      return {
-        success: true,
-        transcript: transcript,
-        transcriptText: transcriptTextPlain.trim(),
-        transcriptTextTimestamped: transcriptTextTimestamped.trim(),
-        language: typeof data.lang === "string" ? data.lang : null,
-      };
+      return buildTranscriptResult(data.content, data.lang);
     }
 
     if (data.status === "failed") {
@@ -1088,6 +1318,7 @@ async function handleSaveNote(
   timestamp,
   videoTitle,
   channelName,
+  tabId,
 ) {
   try {
     const canonicalVideoUrl = YTD_SETTINGS.canonicalYouTubeUrl(videoId);
@@ -1110,7 +1341,10 @@ async function handleSaveNote(
 
     // If no cached transcript, fetch it
     if (!transcript) {
-      const transcriptResult = await handleFetchTranscript(videoId);
+      const transcriptResult = await handleFetchTranscriptLocalFirst(
+        videoId,
+        tabId,
+      );
       if (!transcriptResult.success) {
         return { success: false, error: "Could not fetch transcript" };
       }
@@ -1635,4 +1869,8 @@ globalThis.__YTD_TRANSLATION_TESTING__ = {
   validateTranscriptBatchRequest,
   normalizeTranslatedSegmentBatch,
   handleTranslateContent,
+  buildTranscriptResult,
+  parseTimedtextJson3,
+  pickCaptionTrack,
+  handleFetchTranscriptLocalFirst,
 };

--- a/options.html
+++ b/options.html
@@ -37,9 +37,9 @@
         </div>
         <h1 data-i18n="heading">Bring your own API keys</h1>
         <p class="lede" data-i18n="lede">
-          Keys stay in this Chrome profile and are sent only to Supadata and
-          DeepSeek. This open-source extension has no developer server or
-          analytics.
+          Keys stay in this Chrome profile and are sent only to DeepSeek, plus
+          Supadata when you use it as a fallback. This open-source extension has
+          no developer server or analytics.
         </p>
       </header>
 
@@ -59,7 +59,9 @@
           />
           <p class="help">
             <span data-i18n="supadataHelp"
-              >Used to fetch timestamped YouTube subtitles.</span
+              >Optional. Captions are extracted from the YouTube page
+              directly; this key is only a fallback when extraction
+              fails.</span
             >
             <a
               href="https://dash.supadata.ai/auth/sign-up"

--- a/options.js
+++ b/options.js
@@ -9,10 +9,11 @@ const YTD_OPTIONS = (() => {
       languageGroupLabel: "Interface language",
       heading: "Bring your own API keys",
       lede:
-        "Keys stay in this Chrome profile and are sent only to Supadata and DeepSeek. This open-source extension has no developer server or analytics.",
+        "Keys stay in this Chrome profile and are sent only to DeepSeek, plus Supadata when you use it as a fallback. This open-source extension has no developer server or analytics.",
       transcriptProvider: "Transcript provider",
       supadataApiKeyLabel: "Supadata API key",
-      supadataHelp: "Used to fetch timestamped YouTube subtitles. ",
+      supadataHelp:
+        "Optional. Captions are extracted from the YouTube page directly; this key is only a fallback when extraction fails. ",
       supadataLink: "Create a Supadata account and key",
       supadataHelpSuffix:
         ". Supadata generates the key during onboarding.",
@@ -57,7 +58,6 @@ const YTD_OPTIONS = (() => {
       migrationWarning:
         "Custom provider settings were removed safely. Your Supadata key was kept, but the AI key was cleared. Enter a DeepSeek API key to continue.",
       saving: "Saving…",
-      addSupadataKey: "Add a Supadata API key.",
       addDeepseekKey: "Add a DeepSeek API key.",
       saved: "Saved. Reopen YouTube Digest to use these settings.",
       saveFailed: "Could not save settings. Please try again.",
@@ -79,10 +79,11 @@ const YTD_OPTIONS = (() => {
       languageGroupLabel: "界面语言",
       heading: "使用你自己的 API 密钥",
       lede:
-        "密钥仅保存在当前 Chrome 个人资料中，只会发送给 Supadata 和 DeepSeek。本开源扩展没有开发者服务器，也不使用分析服务。",
+        "密钥仅保存在当前 Chrome 个人资料中，只会发送给 DeepSeek，以及用作兜底时的 Supadata。本开源扩展没有开发者服务器，也不使用分析服务。",
       transcriptProvider: "字幕服务",
       supadataApiKeyLabel: "Supadata API 密钥",
-      supadataHelp: "用于获取带时间戳的 YouTube 字幕。",
+      supadataHelp:
+        "可选。字幕直接从 YouTube 页面提取；仅当本地提取失败时，才需要此密钥作为兜底。",
       supadataLink: "创建 Supadata 账号并获取密钥",
       supadataHelpSuffix: "。Supadata 会在引导流程中生成密钥。",
       aiProvider: "AI 服务",
@@ -125,7 +126,6 @@ const YTD_OPTIONS = (() => {
       migrationWarning:
         "已安全移除自定义服务设置。Supadata 密钥已保留，AI 密钥已清除。请输入 DeepSeek API 密钥以继续使用。",
       saving: "正在保存…",
-      addSupadataKey: "请添加 Supadata API 密钥。",
       addDeepseekKey: "请添加 DeepSeek API 密钥。",
       saved: "已保存。请重新打开 YouTube Digest 以使用这些设置。",
       saveFailed: "无法保存设置，请重试。",
@@ -449,10 +449,8 @@ const YTD_OPTIONS = (() => {
         supadataApiKey: supadataApiKeyInput.value,
       });
 
-      if (!settings.supadataApiKey) {
-        setStatus(saveStatus, "addSupadataKey");
-        return;
-      }
+      // Supadata is optional: captions are extracted from the page locally,
+      // and the key is only a fallback. The AI key remains required.
       if (!settings.aiApiKey) {
         setStatus(saveStatus, "addDeepseekKey");
         return;

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -237,7 +237,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     action: "checkConfig",
   });
 
-  if (!configStatus.hasSupadataKey || !configStatus.hasAiKey) {
+  // Supadata is an optional fallback: the transcript is extracted from the
+  // YouTube page locally when possible, so only the AI key is required.
+  if (!configStatus.hasAiKey) {
     showConfigError(configStatus);
     return;
   }
@@ -611,16 +613,10 @@ async function startDigest(videoId, videoUrl) {
   const transcriptResult = await chrome.runtime.sendMessage({
     action: "fetchTranscript",
     videoId: videoId,
+    tabId: youtubeTabId,
   });
 
   if (!transcriptResult.success) {
-    if (transcriptResult.error === "NO_SUPADATA_KEY") {
-      showError(
-        "API key missing",
-        "Add your Supadata API key in YouTube Digest Settings.",
-      );
-      return;
-    }
     showError(
       "No transcript found",
       transcriptResult.message || transcriptResult.error,
@@ -941,7 +937,6 @@ function showError(title, message) {
 
 function showConfigError(configStatus) {
   const missingKeys = [];
-  if (!configStatus.hasSupadataKey) missingKeys.push("Supadata");
   if (!configStatus.hasAiKey) missingKeys.push("AI provider");
 
   showState("error");

--- a/tests/local-transcript.test.js
+++ b/tests/local-transcript.test.js
@@ -1,0 +1,376 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const root = path.resolve(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+
+function loadBackgroundHelpers({
+  settings = {
+    provider: "deepseek",
+    aiApiKey: "",
+    aiBaseUrl: "https://api.deepseek.com",
+    aiModel: "deepseek-v4-flash",
+    supadataApiKey: "",
+  },
+  fetchImpl = async () => {
+    throw new Error("unexpected fetch");
+  },
+  executeScriptImpl = async () => [{ result: null }],
+} = {}) {
+  const listeners = { addListener() {} };
+  const sandbox = {
+    console,
+    URL,
+    TextDecoder,
+    TextEncoder,
+    fetch: fetchImpl,
+    AbortController,
+    setTimeout,
+    clearTimeout,
+    importScripts() {},
+    chrome: {
+      storage: {
+        local: {
+          setAccessLevel: () => Promise.resolve(),
+          get: async () => ({ ytd_settings: settings }),
+        },
+      },
+      action: { onClicked: listeners },
+      sidePanel: {
+        setPanelBehavior() {},
+        setOptions: () => Promise.resolve(),
+      },
+      runtime: {
+        onInstalled: listeners,
+        onMessage: listeners,
+        openOptionsPage() {},
+        getURL: (resourcePath) => `chrome-extension://test/${resourcePath}`,
+      },
+      tabs: { onUpdated: listeners, onActivated: listeners },
+      scripting: { executeScript: executeScriptImpl },
+    },
+    YTD_SETTINGS: {
+      STORAGE_KEY: "ytd_settings",
+      normalize: (value) => value,
+      chatCompletionsUrl: (baseUrl) => `${baseUrl}/chat/completions`,
+      canonicalYouTubeUrl: (videoId) =>
+        `https://www.youtube.com/watch?v=${videoId}`,
+    },
+  };
+  sandbox.globalThis = sandbox;
+  vm.runInNewContext(read("background.js"), sandbox);
+  return sandbox.__YTD_TRANSLATION_TESTING__;
+}
+
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
+  return { ok, status, json: async () => body };
+}
+
+const BASE_SETTINGS = {
+  provider: "deepseek",
+  aiApiKey: "",
+  aiBaseUrl: "https://api.deepseek.com",
+  aiModel: "deepseek-v4-flash",
+};
+
+const TIMEDTEXT_EVENTS = {
+  events: [
+    {
+      tStartMs: 0,
+      dDurationMs: 5000,
+      segs: [{ utf8: "Hello " }, { utf8: "world" }],
+    },
+    { tStartMs: 5000, dDurationMs: 4000, segs: [{ utf8: "Second line" }] },
+  ],
+};
+
+// ============================================================
+// buildTranscriptResult
+// ============================================================
+
+test("buildTranscriptResult converts chunks into the shared transcript format", () => {
+  const helpers = loadBackgroundHelpers();
+  const result = helpers.buildTranscriptResult(
+    [
+      { text: "First >> line", offset: 1200, duration: 3000, lang: "en" },
+      { text: "Second line", offset: 4200, duration: 2000 },
+    ],
+    "en",
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(result.transcript.length, 2);
+  assert.equal(result.transcript[0].text, "First line");
+  assert.equal(result.transcript[0].start, 1);
+  assert.equal(result.transcript[0].duration, 3);
+  assert.equal(result.transcript[0].language, "en");
+  assert.equal(result.transcript[1].language, "en");
+  assert.equal(result.transcriptText, "First line Second line");
+  assert.equal(
+    result.transcriptTextTimestamped,
+    "[0:01] First line\n[0:04] Second line",
+  );
+  assert.equal(result.language, "en");
+});
+
+test("buildTranscriptResult returns null when no usable text remains", () => {
+  const helpers = loadBackgroundHelpers();
+  assert.equal(helpers.buildTranscriptResult([], "en"), null);
+  assert.equal(
+    helpers.buildTranscriptResult([{ text: ">>", offset: 0 }], "en"),
+    null,
+  );
+});
+
+test("local and Supadata chunks produce identical shared output", () => {
+  const helpers = loadBackgroundHelpers();
+  const supadataResult = helpers.buildTranscriptResult(
+    [{ text: "Hello world", offset: 0, duration: 5000, lang: "en" }],
+    "en",
+  );
+  const localResult = helpers.buildTranscriptResult(
+    [{ text: "Hello world", offset: 0, duration: 5000, lang: "en" }],
+    "en",
+  );
+  assert.deepEqual(localResult, supadataResult);
+});
+
+// ============================================================
+// parseTimedtextJson3
+// ============================================================
+
+test("parseTimedtextJson3 joins segments and normalizes line breaks", () => {
+  const helpers = loadBackgroundHelpers();
+  const chunks = helpers.parseTimedtextJson3(
+    {
+      events: [
+        { tStartMs: 0, dDurationMs: 5000, segs: [{ utf8: "A " }, { utf8: "B" }] },
+        { tStartMs: 5000, dDurationMs: 0, segs: [{ utf8: "Multi\nline" }] },
+        { tStartMs: 9000, segs: [{ utf8: "No duration" }] },
+        { tStartMs: 10000 },
+        { segs: [{ utf8: "  " }] },
+      ],
+    },
+    "en",
+  );
+
+  assert.equal(chunks.length, 3);
+  assert.equal(chunks[0].text, "A B");
+  assert.equal(chunks[0].offset, 0);
+  assert.equal(chunks[0].duration, 5000);
+  assert.equal(chunks[0].lang, "en");
+  assert.equal(chunks[1].text, "Multi line");
+  assert.equal(chunks[2].offset, 9000);
+  assert.equal(chunks[2].duration, 0);
+});
+
+test("parseTimedtextJson3 tolerates missing events", () => {
+  const helpers = loadBackgroundHelpers();
+  // Cross-realm arrays from the vm sandbox are not host-realm arrays, so
+  // compare lengths instead of deep equality.
+  assert.equal(helpers.parseTimedtextJson3({}, "en").length, 0);
+  assert.equal(helpers.parseTimedtextJson3(null, "en").length, 0);
+});
+
+// ============================================================
+// pickCaptionTrack
+// ============================================================
+
+test("pickCaptionTrack prefers exact English, then English variants", () => {
+  const helpers = loadBackgroundHelpers();
+  const tracks = [
+    { baseUrl: "https://www.youtube.com/api/timedtext?lang=fr", languageCode: "fr" },
+    {
+      baseUrl: "https://www.youtube.com/api/timedtext?lang=en-US",
+      languageCode: "en-US",
+    },
+    { baseUrl: "https://www.youtube.com/api/timedtext?lang=en", languageCode: "en" },
+  ];
+
+  assert.equal(helpers.pickCaptionTrack(tracks).languageCode, "en");
+  assert.equal(
+    helpers.pickCaptionTrack(tracks.filter((t) => t.languageCode !== "en"))
+      .languageCode,
+    "en-US",
+  );
+  assert.equal(
+    helpers.pickCaptionTrack([
+      { baseUrl: "https://www.youtube.com/api/timedtext?lang=ja", languageCode: "ja" },
+    ]).languageCode,
+    "ja",
+  );
+  assert.equal(helpers.pickCaptionTrack([]), null);
+  assert.equal(helpers.pickCaptionTrack(null), null);
+});
+
+// ============================================================
+// handleFetchTranscriptLocalFirst orchestration
+// ============================================================
+
+test("local extraction short-circuits before any Supadata call", async () => {
+  let supadataCalled = false;
+  const helpers = loadBackgroundHelpers({
+    settings: { ...BASE_SETTINGS, supadataApiKey: "supadata-key" },
+    executeScriptImpl: async () => [
+      {
+        result: [
+          {
+            baseUrl: "https://www.youtube.com/api/timedtext?lang=en&v=abc123",
+            languageCode: "en",
+          },
+        ],
+      },
+    ],
+    fetchImpl: async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("timedtext")) {
+        return jsonResponse(TIMEDTEXT_EVENTS);
+      }
+      if (urlStr.includes("api.supadata.ai")) {
+        supadataCalled = true;
+        return jsonResponse({
+          content: [{ text: "Supadata line", offset: 3000, duration: 2000 }],
+          lang: "en",
+        });
+      }
+      throw new Error(`unexpected fetch: ${urlStr}`);
+    },
+  });
+
+  const result = await helpers.handleFetchTranscriptLocalFirst("abc123", 42);
+
+  assert.equal(result.success, true);
+  assert.equal(result.source, "local");
+  assert.equal(supadataCalled, false);
+  assert.equal(result.transcript.length, 2);
+  assert.equal(result.transcript[0].text, "Hello world");
+  assert.equal(result.transcript[0].start, 0);
+  assert.equal(result.transcript[1].start, 5);
+  assert.equal(result.transcriptText, "Hello world Second line");
+  assert.equal(
+    result.transcriptTextTimestamped,
+    "[0:00] Hello world\n[0:05] Second line",
+  );
+});
+
+test("local failure falls back to Supadata", async () => {
+  let scriptCalls = 0;
+  let supadataCalled = false;
+  const helpers = loadBackgroundHelpers({
+    settings: { ...BASE_SETTINGS, supadataApiKey: "supadata-key" },
+    executeScriptImpl: async () => {
+      scriptCalls++;
+      return [{ result: null }];
+    },
+    fetchImpl: async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("api.supadata.ai")) {
+        supadataCalled = true;
+        return jsonResponse({
+          content: [{ text: "Supadata >> line", offset: 3000, duration: 2000, lang: "en" }],
+          lang: "en",
+        });
+      }
+      throw new Error(`unexpected fetch: ${urlStr}`);
+    },
+  });
+
+  const result = await helpers.handleFetchTranscriptLocalFirst("abc123", 42);
+
+  assert.equal(result.success, true);
+  assert.equal(result.source, "supadata");
+  assert.equal(scriptCalls, 1);
+  assert.equal(supadataCalled, true);
+  assert.equal(result.transcript[0].text, "Supadata line");
+  assert.equal(result.transcript[0].start, 3);
+});
+
+test("timedtext failure falls back to Supadata", async () => {
+  let supadataCalled = false;
+  const helpers = loadBackgroundHelpers({
+    settings: { ...BASE_SETTINGS, supadataApiKey: "supadata-key" },
+    executeScriptImpl: async () => [
+      {
+        result: [
+          {
+            baseUrl: "https://www.youtube.com/api/timedtext?lang=en&v=abc123",
+            languageCode: "en",
+          },
+        ],
+      },
+    ],
+    fetchImpl: async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("timedtext")) {
+        return jsonResponse({ error: "nope" }, { ok: false, status: 403 });
+      }
+      if (urlStr.includes("api.supadata.ai")) {
+        supadataCalled = true;
+        return jsonResponse({
+          content: [{ text: "Fallback line", offset: 0, duration: 1000 }],
+          lang: "en",
+        });
+      }
+      throw new Error(`unexpected fetch: ${urlStr}`);
+    },
+  });
+
+  const result = await helpers.handleFetchTranscriptLocalFirst("abc123", 42);
+
+  assert.equal(result.success, true);
+  assert.equal(result.source, "supadata");
+  assert.equal(supadataCalled, true);
+});
+
+test("no tabId skips local extraction entirely", async () => {
+  let scriptCalls = 0;
+  const helpers = loadBackgroundHelpers({
+    settings: { ...BASE_SETTINGS, supadataApiKey: "supadata-key" },
+    executeScriptImpl: async () => {
+      scriptCalls++;
+      return [{ result: null }];
+    },
+    fetchImpl: async (url) => {
+      if (String(url).includes("api.supadata.ai")) {
+        return jsonResponse({
+          content: [{ text: "Fallback line", offset: 0, duration: 1000 }],
+          lang: "en",
+        });
+      }
+      throw new Error(`unexpected fetch: ${String(url)}`);
+    },
+  });
+
+  const result = await helpers.handleFetchTranscriptLocalFirst("abc123", null);
+
+  assert.equal(result.success, true);
+  assert.equal(result.source, "supadata");
+  assert.equal(scriptCalls, 0);
+});
+
+test("combined error when local extraction fails and no Supadata key exists", async () => {
+  const helpers = loadBackgroundHelpers({
+    settings: { ...BASE_SETTINGS, supadataApiKey: "" },
+    executeScriptImpl: async () => [{ result: null }],
+  });
+
+  const result = await helpers.handleFetchTranscriptLocalFirst("abc123", 42);
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, "NO_TRANSCRIPT");
+  assert.match(result.message, /Supadata API key/);
+});
+
+test("missing Supadata key without a tabId keeps the original error", async () => {
+  const helpers = loadBackgroundHelpers({
+    settings: { ...BASE_SETTINGS, supadataApiKey: "" },
+  });
+
+  const result = await helpers.handleFetchTranscriptLocalFirst("abc123", null);
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, "NO_SUPADATA_KEY");
+});


### PR DESCRIPTION
## Summary

Fetch YouTube caption tracks directly from the page's own player state and read subtitles from YouTube's timedtext endpoint, so transcript retrieval works without a Supadata account. Supadata remains as an optional fallback when local extraction fails.

## Changes

- **background.js**: shared `buildTranscriptResult` used by both the local and Supadata paths; new local extraction chain (`readCaptionTracksFromTab` → `pickCaptionTrack` → `fetchTimedtextTranscript`) reading `getPlayerResponse()` / `ytInitialPlayerResponse`; new `handleFetchTranscriptLocalFirst` orchestrator that falls back to Supadata and tags results with their source. `fetchTranscript` and `saveNote` now thread the YouTube tab id through.
- **sidepanel.js**: sends the tab id with transcript requests; only the AI key is now required (Supadata is optional); clearer error message when local extraction fails with no fallback key.
- **options.js / options.html**: Supadata key is optional, with updated bilingual help text and validation.
- **README.md / README.zh-CN.md / PRIVACY.md**: document the local-first flow and optional Supadata fallback.
- **tests/local-transcript.test.js**: 12 new tests covering chunk conversion, JSON3 parsing, track selection, and orchestration short-circuit/fallback behavior.

## Verification

- `npm test`: 54 pass
- `npm run check`: release checks passed
- `npm run package`: built successfully

## Notes

Local extraction needs no API key and no credits. English track preference is preserved (`en` → `en-*` → first available). When local extraction fails and no Supadata key is configured, the user gets a combined explanation instead of a key-required prompt.