### PR TITLE
Add bilingual video captions and transcript playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ skills-lock.json
 .playwright-mcp/
 node_modules/
 dist/
+.workbuddy/
 
 # Environment
 .env

--- a/background.js
+++ b/background.js
@@ -230,21 +230,13 @@ async function readBoundedAiResponse(response, onActivity) {
 // ============================================================
 
 /**
- * When the user clicks the extension icon, open the side panel.
- * Chrome's Side Panel API lets us show a persistent panel alongside the page.
- */
-chrome.action.onClicked.addListener((tab) => {
-  // Re-enable + open without awaiting — preserves user gesture context
-  chrome.sidePanel.setOptions({
-    tabId: tab.id,
-    path: "sidepanel.html",
-    enabled: true,
-  });
-  chrome.sidePanel.open({ tabId: tab.id });
-});
-
-/**
- * Allow the side panel to open on any page, but it's designed for YouTube.
+ * Open the side panel when the user clicks the extension icon.
+ *
+ * `openPanelOnActionClick: true` makes Chrome open the panel directly on the
+ * action click; when this is enabled Chrome does NOT dispatch
+ * `chrome.action.onClicked`, so no separate listener is needed here. Panel
+ * enable/disable per tab is handled by updatePanelForTab(), and the Digest
+ * button on YouTube pages opens the panel via the openSidePanel message.
  */
 chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 
@@ -395,6 +387,25 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
+  // Bilingual-caption toggle preference. Content scripts run in an untrusted
+  // storage context, so they read/write this via the service worker instead of
+  // touching chrome.storage directly.
+  if (message.action === "getCaptionsPref") {
+    chrome.storage.local
+      .get("ytd_captions_enabled")
+      .then((stored) => sendResponse({ enabled: !!stored.ytd_captions_enabled }))
+      .catch(() => sendResponse({ enabled: false }));
+    return true;
+  }
+
+  if (message.action === "setCaptionsPref") {
+    chrome.storage.local
+      .set({ ytd_captions_enabled: !!message.enabled })
+      .then(() => sendResponse({ success: true }))
+      .catch((error) => sendResponse({ success: false, error: error.message }));
+    return true;
+  }
+
   if (message.action === "openOptions") {
     chrome.runtime.openOptionsPage();
     sendResponse({ success: true });
@@ -421,7 +432,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           // Broadcast to side panel to start digest (in case it's already open)
           setTimeout(() => {
             chrome.runtime
-              .sendMessage({ action: "startDigestFromButton" })
+              .sendMessage({ action: "startDigestFromButton", tabId })
               .catch(() => {});
           }, 300);
         })
@@ -458,12 +469,28 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     debugLog("[YouTube Digest BG] Relay request:", message.payload?.action);
     (async () => {
       try {
+        const targetTabId = Number.isInteger(message.tabId)
+          ? message.tabId
+          : null;
+        let targetTab = null;
+
+        if (targetTabId !== null) {
+          try {
+            const candidate = await chrome.tabs.get(targetTabId);
+            if (candidate?.url?.includes("youtube.com")) targetTab = candidate;
+          } catch (e) {
+            debugLog("[YouTube Digest BG] Target tab unavailable:", e.message);
+          }
+        }
+
         // Query specifically for YouTube tabs to avoid side panel context issues
         // Try multiple query strategies to find the right tab
-        let tabs = await chrome.tabs.query({
-          active: true,
-          lastFocusedWindow: true,
-        });
+        let tabs = targetTab
+          ? [targetTab]
+          : await chrome.tabs.query({
+              active: true,
+              lastFocusedWindow: true,
+            });
         debugLog(
           "[YouTube Digest BG] Active tab in last focused window:",
           tabs.length,
@@ -779,7 +806,7 @@ async function pollTranscriptJob(jobId, supadataApiKey) {
               language: chunk.lang || data.lang || null,
             });
             transcriptTextPlain += cleanText + " ";
-            transcriptTextTimestamped += `[${timestamp}] ${chunk.text}\n`;
+            transcriptTextTimestamped += `[${timestamp}] ${cleanText}\n`;
           }
         }
       }
@@ -1053,9 +1080,18 @@ function validateAndFixTimestamps(analysis, maxSeconds) {
  */
 async function handleGetVideoInfo(tabId) {
   try {
-    const response = await chrome.tabs.sendMessage(tabId, {
+    let response = await chrome.tabs.sendMessage(tabId, {
       action: "getVideoInfo",
     });
+    const playerInfo = await getPlayerVideoDetails(tabId);
+    if (playerInfo) {
+      response = {
+        title: playerInfo.title || response?.title || "",
+        channelName: playerInfo.channelName || response?.channelName || "",
+        duration: playerInfo.duration || response?.duration || 0,
+        description: playerInfo.description || response?.description || "",
+      };
+    }
     return response;
   } catch (error) {
     return { title: "", channelName: "", description: "" };

--- a/background.js
+++ b/background.js
@@ -1547,8 +1547,8 @@ function normalizeTranslatedSegmentBatch(parsed, sourceSegments) {
 
 /**
  * Translates content using DeepSeek.
- * @param {Object} content - JSON object containing semantic transcript segments
- * @param {string} contentType - Must be 'transcriptBatch'
+ * @param {Object|string} content - Transcript segments or selected text
+ * @param {string} contentType - 'transcriptBatch' or 'selectedText'
  * @param {string} targetLanguage - 'zh' for Simplified Chinese
  * @param {string} videoTitle - The video title (for context)
  * @returns {Object} - { success, translatedContent } or { success: false, error }
@@ -1566,7 +1566,7 @@ async function handleTranslateContent(
         error: `Unsupported translation target: ${String(targetLanguage)}`,
       };
     }
-    if (contentType !== "transcriptBatch") {
+    if (!["transcriptBatch", "selectedText"].includes(contentType)) {
       return {
         success: false,
         error: `Unsupported translation content type: ${String(contentType)}`,
@@ -1576,6 +1576,39 @@ async function handleTranslateContent(
     const settings = await getSettings();
     if (!settings.aiApiKey) {
       return { success: false, error: "DeepSeek API key not configured" };
+    }
+
+    if (contentType === "selectedText") {
+      const selectedText = String(content?.text ?? content ?? "").trim();
+      if (!selectedText) {
+        return { success: false, error: "Selected text is empty" };
+      }
+      if (selectedText.length > 4000) {
+        return { success: false, error: "Selected text is too long" };
+      }
+
+      const langName = "Simplified Chinese";
+      const baseRules = await getTranslationBaseRules(targetLanguage);
+      const systemPrompt = await loadPromptSection(
+        "translation.md",
+        "Selected text translation",
+        {
+          langName,
+          videoTitle: videoTitle || "Unknown",
+          baseRules,
+        },
+      );
+      const result = await callAiTranslation(systemPrompt, selectedText, {
+        temperature: 0.2,
+        maxTokens: 1024,
+      });
+      if (!result.success) return result;
+
+      const text = result.text.trim();
+      if (!text) {
+        return { success: false, error: "Translation returned empty text" };
+      }
+      return { success: true, translatedContent: { text } };
     }
 
     const sourceSegments = validateTranscriptBatchRequest(content);

--- a/background.js
+++ b/background.js
@@ -19,6 +19,13 @@ const DEBUG = false;
 const AI_PROVIDER_IDLE_TIMEOUT_MS = 50_000;
 const AI_PROVIDER_HARD_TIMEOUT_MS = 120_000;
 const AI_PROVIDER_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const TRANSCRIPT_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+// "This video has no captions" is a property of the video, not a transient
+// condition — captions don't appear out of nowhere. Cache the failure briefly
+// so the panel, captions overlay, and note flow stop burning a Supadata
+// request on every tab switch / click for the same caption-less video.
+const TRANSCRIPT_FAILURE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const transcriptFetchPromises = new Map();
 const debugLog = (...args) => {
   if (DEBUG) console.log(...args);
 };
@@ -604,6 +611,163 @@ async function getPlayerVideoDetails(tabId) {
 // TRANSCRIPT FETCHING VIA SUPADATA API
 // ============================================================
 
+function transcriptCacheKey(videoId) {
+  return `digest_${videoId}`;
+}
+
+function cachedDigestToTranscriptResult(cached) {
+  if (!cached || !Array.isArray(cached.transcript)) return null;
+  return {
+    success: true,
+    transcript: cached.transcript,
+    transcriptText: String(cached.transcriptText || "").trim(),
+    transcriptTextTimestamped: String(
+      cached.transcriptTimestamped || cached.transcriptTextTimestamped || "",
+    ).trim(),
+    language: cached.transcriptLanguage || cached.language || null,
+  };
+}
+
+async function readCachedTranscript(videoId) {
+  if (!videoId) return null;
+
+  try {
+    const key = transcriptCacheKey(videoId);
+    const result = await chrome.storage.local.get(key);
+    const cached = result[key];
+    if (!cached) return null;
+
+    const timestamp = Number(cached.timestamp) || 0;
+    if (Date.now() - timestamp > TRANSCRIPT_CACHE_TTL_MS) {
+      await chrome.storage.local.remove(key);
+      return null;
+    }
+
+    return cachedDigestToTranscriptResult(cached);
+  } catch (error) {
+    debugLog("[YouTube Digest] Transcript cache read failed:", error);
+    return null;
+  }
+}
+
+async function writeCachedTranscript(videoId, transcriptResult) {
+  if (!videoId || !transcriptResult?.success) return;
+
+  try {
+    const key = transcriptCacheKey(videoId);
+    const existing = await chrome.storage.local.get(key);
+    const previous = existing[key] || {};
+    await chrome.storage.local.set({
+      [key]: {
+        ...previous,
+        transcript: transcriptResult.transcript,
+        transcriptText: transcriptResult.transcriptText,
+        transcriptTimestamped: transcriptResult.transcriptTextTimestamped,
+        transcriptLanguage: transcriptResult.language,
+        timestamp: Date.now(),
+      },
+    });
+  } catch (error) {
+    debugLog("[YouTube Digest] Transcript cache write failed:", error);
+  }
+}
+
+// Which Supadata errors describe a *property of the video* (no captions at
+// all) rather than a transient condition. These are safe to cache briefly.
+// Transient errors (RATE_LIMITED, INVALID_KEY, network, job timeouts) must
+// NOT be cached — the user should be able to retry them right away.
+const TRANSCRIPT_CACHEABLE_ERRORS = new Set([
+  "NO_TRANSCRIPT",
+  "EMPTY_TRANSCRIPT",
+]);
+
+function failedTranscriptCacheKey(videoId) {
+  return `digest_failed_${videoId}`;
+}
+
+async function readFailedTranscript(videoId) {
+  if (!videoId) return null;
+
+  try {
+    const key = failedTranscriptCacheKey(videoId);
+    const result = await chrome.storage.local.get(key);
+    const failed = result[key];
+    if (!failed) return null;
+
+    const timestamp = Number(failed.timestamp) || 0;
+    if (Date.now() - timestamp > TRANSCRIPT_FAILURE_CACHE_TTL_MS) {
+      await chrome.storage.local.remove(key);
+      return null;
+    }
+
+    return {
+      success: false,
+      error: failed.error,
+      message: failed.message || "No transcript available for this video.",
+    };
+  } catch (error) {
+    debugLog("[YouTube Digest] Failed-transcript cache read failed:", error);
+    return null;
+  }
+}
+
+async function writeFailedTranscript(videoId, transcriptResult) {
+  if (!videoId || transcriptResult?.success) return;
+  if (!TRANSCRIPT_CACHEABLE_ERRORS.has(transcriptResult.error)) return;
+
+  try {
+    await chrome.storage.local.set({
+      [failedTranscriptCacheKey(videoId)]: {
+        error: transcriptResult.error,
+        message: transcriptResult.message || "",
+        timestamp: Date.now(),
+      },
+    });
+  } catch (error) {
+    debugLog("[YouTube Digest] Failed-transcript cache write failed:", error);
+  }
+}
+
+/**
+ * Fetches the transcript for a YouTube video using Supadata API.
+ *
+ * All callers go through this function so one video costs at most one
+ * Supadata transcript request while the cache is valid, even when the side
+ * panel, player captions, and notes feature ask at nearly the same time.
+ *
+ * @param {string} videoId - The YouTube video ID (e.g., "dQw4w9WgXcQ")
+ * @returns {Object} - { success, transcript, transcriptText, language } or { success: false, error }
+ */
+async function handleFetchTranscript(videoId) {
+  const cached = await readCachedTranscript(videoId);
+  if (cached) return cached;
+
+  // A recent "this video has no captions" failure is cached too, so we don't
+  // re-hit Supadata for the same caption-less video on every trigger.
+  const failed = await readFailedTranscript(videoId);
+  if (failed) return failed;
+
+  if (transcriptFetchPromises.has(videoId)) {
+    return transcriptFetchPromises.get(videoId);
+  }
+
+  const promise = fetchTranscriptFromSupadata(videoId).then(async (result) => {
+    if (result.success) {
+      await writeCachedTranscript(videoId, result);
+    } else {
+      await writeFailedTranscript(videoId, result);
+    }
+    return result;
+  });
+  transcriptFetchPromises.set(videoId, promise);
+
+  try {
+    return await promise;
+  } finally {
+    transcriptFetchPromises.delete(videoId);
+  }
+}
+
 /**
  * Fetches the transcript for a YouTube video using Supadata API.
  *
@@ -616,7 +780,7 @@ async function getPlayerVideoDetails(tabId) {
  * @param {string} videoId - The YouTube video ID (e.g., "dQw4w9WgXcQ")
  * @returns {Object} - { success, transcript, transcriptText, language } or { success: false, error }
  */
-async function handleFetchTranscript(videoId) {
+async function fetchTranscriptFromSupadata(videoId) {
   try {
     const settings = await getSettings();
     if (!settings.supadataApiKey) {

--- a/content.js
+++ b/content.js
@@ -31,6 +31,26 @@ let digestButtonObserver = null;
 let digestButtonReconcileTimer = null;
 let digestButtonResizeListenerAdded = false;
 
+// --- Bilingual captions state ---
+let ytdCaptionsToggle = null;
+let ytdCaptionsOverlay = null;
+let ytdCaptionsTimeUpdateBound = false;
+let ytdCaptionsToggleTimer = null;
+let ytdCaptionsHoverHost = null;
+let captionsFontSizeBound = false;
+const ytdCaptionsState = {
+  enabled: false,
+  videoId: null,
+  videoTitle: "",
+  pages: [], // [{ id, start, duration, text }] — merged caption chunks
+  translations: [], // per-page translated string or ""
+  queue: [],
+  queued: new Set(),
+  processing: false,
+  currentIndex: -1,
+  generation: 0,
+};
+
 // ============================================================
 // INITIALIZATION
 // ============================================================
@@ -49,6 +69,8 @@ function init() {
   // Try to inject the buttons immediately
   injectDigestButton();
   tryInjectNoteButton();
+  ensureCaptionsUI();
+  restoreCaptionsPreference();
 
   // Also set up an observer to handle YouTube's dynamic content loading
   // (YouTube is an SPA, so elements appear/disappear as you navigate)
@@ -379,6 +401,7 @@ function setupButtonObserver() {
       if (!ytdNoteButton || !ytdNoteButton.isConnected) {
         tryInjectNoteButton();
       }
+      ensureCaptionsUI();
     }
   });
 
@@ -546,6 +569,9 @@ function resetNoteButtonTimer() {
 function handleNoteKeyboardShortcut(e) {
   if (!window.location.pathname.includes("/watch")) return;
   if (e.key !== "n" && e.key !== "N") return;
+
+  // Don't hijack browser/system shortcuts (e.g. Cmd+N, Ctrl+Shift+N)
+  if (e.ctrlKey || e.metaKey || e.altKey) return;
 
   // Ignore if the user is typing in an input/textarea/contenteditable
   const active = document.activeElement;
@@ -835,9 +861,668 @@ document.addEventListener("yt-navigate-finish", () => {
   const existingToast = document.getElementById("ytd-note-toast");
   if (existingToast) existingToast.remove();
 
+  // Reset bilingual captions for the new video
+  const existingCaptionsOverlay = document.getElementById("ytd-captions-overlay");
+  if (existingCaptionsOverlay) existingCaptionsOverlay.remove();
+  const existingCaptionsToggle = document.getElementById("ytd-captions-toggle");
+  if (existingCaptionsToggle) existingCaptionsToggle.remove();
+  ytdCaptionsOverlay = null;
+  ytdCaptionsToggle = null;
+  ytdCaptionsHoverHost = null;
+  resetCaptionsState();
+
   // Re-inject buttons for the new video (with a small delay for YouTube to render)
   setTimeout(() => {
     scheduleDigestButtonReconciliation(0);
     tryInjectNoteButton();
+    ensureCaptionsUI();
+    restoreCaptionsPreference();
   }, 500);
 });
+
+// ============================================================
+// BILINGUAL CAPTIONS (self-rendered overlay subtitles)
+// ============================================================
+
+/**
+ * Self-rendered bilingual subtitles. Unlike YouTube's native captions (which
+ * require the viewer to enable CC), these show the original caption line plus
+ * a Simplified Chinese translation below it, driven by the player's playback
+ * time. The subtitle data comes from Supadata via the background's
+ * `fetchTranscript` handler, and translations reuse the background's
+ * `translateContent` transcriptBatch path — queued in small sequential batches
+ * so the provider is never flooded.
+ */
+
+function findCaptionsHost() {
+  return document.querySelector(
+    "#movie_player.html5-video-player, #movie_player, .html5-video-player",
+  );
+}
+
+const CAPTIONS_SEGMENT_LIMITS = Object.freeze({
+  minChars: 60,
+  idealChars: 180,
+  maxChars: 320,
+  maxSeconds: 20,
+});
+
+function normalizeCaptionText(text) {
+  return String(text || "")
+    .replace(/\s+/g, " ")
+    .replace(/([\u3400-\u9fff])\s+([\u3400-\u9fff])/g, "$1$2")
+    .replace(/([，。；：！？])\s+(?=[\u3400-\u9fff])/g, "$1")
+    .replace(/\s+([,.;:!?，。；：！？])/g, "$1")
+    .trim();
+}
+
+function splitOversizedThought(text, maxChars) {
+  const parts = [];
+  let rest = normalizeCaptionText(text);
+
+  while (rest.length > maxChars) {
+    const windowText = rest.slice(0, maxChars + 1);
+    const lowerBound = Math.floor(maxChars * 0.55);
+    let cut = -1;
+
+    for (const pattern of [/[;:；：]\s*/g, /[,，]\s*/g, /\s/g]) {
+      pattern.lastIndex = 0;
+      let match;
+      while ((match = pattern.exec(windowText))) {
+        if (match.index >= lowerBound) cut = match.index + match[0].length;
+      }
+      if (cut > 0) break;
+    }
+
+    if (cut <= 0) cut = maxChars;
+    parts.push(rest.slice(0, cut).trim());
+    rest = rest.slice(cut).trim();
+  }
+
+  if (rest) parts.push(rest);
+  return parts;
+}
+
+/**
+ * Semantic grouping identical to the side panel's groupTranscriptEntries, so
+ * overlay subtitles break at exactly the same points as the right-hand
+ * transcript list. Returns [{ id, start, text }] without duration; callers
+ * derive the window from the next segment's start.
+ */
+function groupCaptionsIntoPages(entries, limits = CAPTIONS_SEGMENT_LIMITS) {
+  if (!Array.isArray(entries) || entries.length === 0) return [];
+
+  const pieces = [];
+  entries.forEach((entry, entryIndex) => {
+    const text = normalizeCaptionText(entry?.text);
+    if (!text) return;
+    const start = Number.isFinite(Number(entry.start)) ? Number(entry.start) : 0;
+    const duration = Math.max(0, Number(entry.duration) || 0);
+    const sentenceParts =
+      text.match(/[^.!?;:,。！？；：，]+(?:[.!?;:,。！？；：，]+["')\]”’）】」』]*|$)/g) ||
+      [text];
+    let consumedChars = 0;
+
+    sentenceParts.forEach((sentencePart) => {
+      const cleanPart = normalizeCaptionText(sentencePart);
+      if (!cleanPart) return;
+      const oversizedParts = splitOversizedThought(cleanPart, limits.maxChars);
+      oversizedParts.forEach((part, partIndex) => {
+        const ratio = text.length ? Math.min(1, consumedChars / text.length) : 0;
+        pieces.push({
+          text: part,
+          start: start + duration * ratio,
+          semanticEnd:
+            /[.!?。！？]["')\]”’）】」』]*$/.test(part) ||
+            oversizedParts.length > 1,
+          clauseEnd: /[;:,；：，]["')\]”’）】」』]*$/.test(part),
+          sourceOrder: `${entryIndex}:${partIndex}`,
+        });
+        consumedChars += part.length + 1;
+      });
+    });
+  });
+
+  const grouped = [];
+  let current = null;
+
+  const flush = () => {
+    if (!current || !current.text.trim()) return;
+    const text = normalizeCaptionText(current.text);
+    grouped.push({
+      id: `segment-${grouped.length}-${Math.round(current.start * 1000)}`,
+      start: current.start,
+      text,
+    });
+    current = null;
+  };
+
+  pieces.forEach((piece) => {
+    if (!current) current = { start: piece.start, text: "" };
+    current.text = normalizeCaptionText(`${current.text} ${piece.text}`);
+    const elapsed = Math.max(0, piece.start - current.start);
+    const comfortablySized = current.text.length >= limits.minChars;
+    const reachedIdeal = current.text.length >= limits.idealChars;
+    const atNaturalBoundary =
+      piece.semanticEnd ||
+      (piece.clauseEnd &&
+        (reachedIdeal ||
+          current.text.length >= limits.maxChars ||
+          elapsed >= limits.maxSeconds));
+    const reachedGuardrail =
+      atNaturalBoundary &&
+      (current.text.length >= limits.maxChars || elapsed >= limits.maxSeconds);
+    const reachedHardGuardrail =
+      current.text.length >= Math.round(limits.maxChars * 1.2) ||
+      elapsed >= limits.maxSeconds + 5;
+
+    if (
+      (atNaturalBoundary && (comfortablySized || elapsed >= 8)) ||
+      (atNaturalBoundary && reachedIdeal) ||
+      reachedGuardrail ||
+      reachedHardGuardrail
+    ) {
+      flush();
+    }
+  });
+  flush();
+
+  return grouped;
+}
+
+function createCaptionsOverlay() {
+  const overlay = document.createElement("div");
+  overlay.id = "ytd-captions-overlay";
+
+  const original = document.createElement("div");
+  original.className = "ytd-captions-original";
+  original.style.cssText = `
+    color: #ffffff;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 1.4;
+    text-shadow: 0 1px 3px rgba(0,0,0,0.9);
+  `;
+
+  const translated = document.createElement("div");
+  translated.className = "ytd-captions-translated";
+  translated.style.cssText = `
+    color: #ffd66b;
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.45;
+    margin-top: 4px;
+    text-shadow: 0 1px 3px rgba(0,0,0,0.9);
+    display: none;
+  `;
+
+  overlay.appendChild(original);
+  overlay.appendChild(translated);
+
+  overlay.style.cssText = `
+    position: absolute;
+    left: 50%;
+    bottom: 72px;
+    transform: translateX(-50%);
+    width: max-content;
+    max-width: 88%;
+    z-index: 60;
+    text-align: center;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    font-family: "Roboto", "Arial", sans-serif;
+    background: rgba(8, 8, 8, 0.55);
+    border-radius: 8px;
+    padding: 10px 18px;
+  `;
+
+  return overlay;
+}
+
+/**
+ * Scale subtitle text and the toggle's spacing with the player, matching
+ * YouTube's native captions: smaller on small screens/embeds, larger in
+ * fullscreen and big windows.
+ */
+function updateCaptionsFontSize() {
+  const player = findCaptionsHost();
+  if (!player) return;
+  const width = player.getBoundingClientRect().width;
+  if (!Number.isFinite(width) || width <= 0) return;
+
+  // Subtitle text: ~1.7% of player width, clamped to a comfortable range.
+  const originalSize = Math.max(12, Math.min(22, Math.round(width * 0.017)));
+  const translatedSize = Math.max(10, Math.round(originalSize * 0.82));
+  if (ytdCaptionsOverlay) {
+    const original = ytdCaptionsOverlay.querySelector(".ytd-captions-original");
+    const translated = ytdCaptionsOverlay.querySelector(".ytd-captions-translated");
+    if (original) original.style.fontSize = `${originalSize}px`;
+    if (translated) translated.style.fontSize = `${translatedSize}px`;
+  }
+
+  // Toggle margin-right: keep the gap proportional so small screens don't
+  // show a huge empty slot between the toggle and YouTube's CC button.
+  if (ytdCaptionsToggle) {
+    const spacing = Math.max(6, Math.min(25, Math.round(width * 0.018)));
+    ytdCaptionsToggle.style.marginRight = `${spacing}px`;
+  }
+}
+
+function bindCaptionsFontSize() {
+  if (captionsFontSizeBound) return;
+  captionsFontSizeBound = true;
+  window.addEventListener("resize", updateCaptionsFontSize);
+  document.addEventListener("fullscreenchange", updateCaptionsFontSize);
+}
+
+function createCaptionsToggle() {
+  const toggle = document.createElement("button");
+  toggle.id = "ytd-captions-toggle";
+  toggle.type = "button";
+  toggle.setAttribute("aria-label", "Toggle bilingual captions");
+  // Subtitle icon + label, sized to sit inside YouTube's control rail.
+  toggle.innerHTML = `
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0;">
+      <rect x="2" y="4" width="20" height="16" rx="2"></rect>
+      <line x1="6" y1="12" x2="11" y2="12"></line>
+      <line x1="13" y1="12" x2="18" y2="12"></line>
+      <line x1="6" y1="16" x2="9" y2="16"></line>
+      <line x1="11" y1="16" x2="18" y2="16"></line>
+    </svg>
+    <span style="font-size: 12px; font-weight: 600; line-height: 1; margin-left: 6px; white-space: nowrap;">双语字幕</span>
+  `;
+
+  // Absolutely positioned to sit in the open area between the play button and
+  // YouTube's native right-side control rail. right: 300px clears CC, settings,
+  // PiP, and fullscreen with ~80px breathing room; bottom: 8px aligns the
+  // baseline with the rail itself, not the player frame.
+  toggle.style.cssText = `
+    display: inline-flex;
+    align-items: center;
+    height: 40px;
+    margin: 0 100px 0 0;
+    padding: 0 12px;
+    border: none;
+    border-radius: 999px;
+    z-index: 9999;
+    font-family: system-ui, -apple-system, "Roboto", sans-serif;
+    color: #ffffff;
+    cursor: pointer;
+    transition: background 0.15s ease;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 1;
+    pointer-events: auto;
+  `;
+
+  // Mimic YouTube's control hover wash when the feature is off.
+  toggle.addEventListener("mouseenter", () => {
+    if (!ytdCaptionsState.enabled) {
+      toggle.style.background = "rgba(255, 255, 255, 0.1)";
+    }
+  });
+  toggle.addEventListener("mouseleave", () => {
+    updateCaptionsToggleStyle();
+  });
+
+  toggle.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleCaptions();
+  });
+
+  return toggle;
+}
+
+function showCaptionsToggle() {
+  if (!ytdCaptionsToggle) return;
+  ytdCaptionsToggle.style.opacity = "1";
+  ytdCaptionsToggle.style.pointerEvents = "auto";
+}
+
+function hideCaptionsToggle() {
+  if (!ytdCaptionsToggle) return;
+  ytdCaptionsToggle.style.opacity = "0";
+  ytdCaptionsToggle.style.pointerEvents = "none";
+}
+
+function resetCaptionsToggleTimer() {
+  clearTimeout(ytdCaptionsToggleTimer);
+  ytdCaptionsToggleTimer = setTimeout(hideCaptionsToggle, 2000);
+}
+
+function bindCaptionsHover(playerContainer) {
+  if (ytdCaptionsHoverHost === playerContainer) return;
+  ytdCaptionsHoverHost = playerContainer;
+
+  playerContainer.addEventListener("mouseenter", () => {
+    showCaptionsToggle();
+    resetCaptionsToggleTimer();
+  });
+  playerContainer.addEventListener("mousemove", () => {
+    showCaptionsToggle();
+    resetCaptionsToggleTimer();
+  });
+  playerContainer.addEventListener("mouseleave", () => {
+    clearTimeout(ytdCaptionsToggleTimer);
+    ytdCaptionsToggleTimer = null;
+    hideCaptionsToggle();
+  });
+}
+
+function ensureCaptionsUI() {
+  if (!window.location.pathname.includes("/watch")) return;
+  const playerContainer = findCaptionsHost();
+  if (!playerContainer) return;
+
+  // The toggle is absolutely positioned; the player must be a positioning
+  // context so right/bottom resolve against the video rather than the page.
+  if (
+    window.getComputedStyle(playerContainer).position === "static" ||
+    !playerContainer.style.position
+  ) {
+    playerContainer.style.position = "relative";
+  }
+
+  if (!ytdCaptionsOverlay || !ytdCaptionsOverlay.isConnected) {
+    ytdCaptionsOverlay = createCaptionsOverlay();
+    playerContainer.appendChild(ytdCaptionsOverlay);
+  }
+  updateCaptionsFontSize();
+  bindCaptionsFontSize();
+  if (!ytdCaptionsToggle || !ytdCaptionsToggle.isConnected) {
+    ytdCaptionsToggle = createCaptionsToggle();
+    // Insert into YouTube's native right-side control rail so the button
+    // inherits its height, hover timing, and bottom alignment. A 60px
+    // margin-right (set in createCaptionsToggle) keeps clear of CC.
+    const rightControls = playerContainer.querySelector(".ytp-right-controls");
+    if (rightControls) {
+      rightControls.insertBefore(ytdCaptionsToggle, rightControls.firstChild);
+    } else {
+      playerContainer.appendChild(ytdCaptionsToggle);
+    }
+    updateCaptionsToggleStyle();
+  }
+}
+
+function updateCaptionsToggleStyle() {
+  if (!ytdCaptionsToggle) return;
+  ytdCaptionsToggle.style.background = ytdCaptionsState.enabled
+    ? "rgba(200, 103, 79, 0.9)"
+    : "rgba(0, 0, 0, 0.5)";
+}
+
+async function restoreCaptionsPreference() {
+  if (!window.location.pathname.includes("/watch")) return;
+  try {
+    const response = await chrome.runtime.sendMessage({
+      action: "getCaptionsPref",
+    });
+    const enabled = !!response?.enabled;
+    ytdCaptionsState.enabled = enabled;
+    updateCaptionsToggleStyle();
+    // loadBilingualCaptions is idempotent per video, so an already-loaded
+    // video just re-reveals and tops up translations.
+    if (enabled) await loadBilingualCaptions();
+  } catch (_error) {
+    // Preference read failed; keep captions off.
+  }
+}
+
+async function toggleCaptions() {
+  const next = !ytdCaptionsState.enabled;
+  ytdCaptionsState.enabled = next;
+  updateCaptionsToggleStyle();
+  try {
+    await chrome.runtime.sendMessage({ action: "setCaptionsPref", enabled: next });
+  } catch (_error) {
+    // Persisting the preference is best-effort; the current view still works.
+  }
+
+  if (next) {
+    await loadBilingualCaptions();
+  } else {
+    hideCaptionsOverlay();
+    ytdCaptionsState.generation += 1;
+    ytdCaptionsState.queue = [];
+    ytdCaptionsState.queued.clear();
+  }
+}
+
+async function loadBilingualCaptions() {
+  const videoId = new URLSearchParams(window.location.search).get("v");
+  if (!videoId) return;
+
+  // Same video already loaded — just reveal and top up translations.
+  if (ytdCaptionsState.videoId === videoId && ytdCaptionsState.pages.length) {
+    showCaptionsOverlay();
+    enqueueCaptionsTranslations(
+      ytdCaptionsState.currentIndex >= 0 ? ytdCaptionsState.currentIndex : 0,
+    );
+    return;
+  }
+
+  ytdCaptionsState.generation += 1;
+  const generation = ytdCaptionsState.generation;
+  ytdCaptionsState.videoId = videoId;
+  ytdCaptionsState.videoTitle = extractVideoInfo().title;
+  ytdCaptionsState.pages = [];
+  ytdCaptionsState.translations = [];
+  ytdCaptionsState.queue = [];
+  ytdCaptionsState.queued.clear();
+  ytdCaptionsState.currentIndex = -1;
+
+  showCaptionsLoading();
+
+  try {
+    const result = await chrome.runtime.sendMessage({
+      action: "fetchTranscript",
+      videoId,
+    });
+    if (generation !== ytdCaptionsState.generation) return;
+
+    if (result?.success && Array.isArray(result.transcript)) {
+      const cleanChunks = result.transcript
+        .filter((chunk) => chunk && typeof chunk.text === "string" && chunk.text.trim())
+        .map((chunk) => ({
+          start: Math.max(0, Math.floor(Number(chunk.start) || 0)),
+          duration: Math.max(0.5, Math.floor(Number(chunk.duration) || 0)),
+          text: chunk.text.replace(/>> ?/g, "").trim(),
+        }));
+      const grouped = groupCaptionsIntoPages(cleanChunks);
+      ytdCaptionsState.pages = grouped.map((segment, index) => ({
+        id: segment.id,
+        start: segment.start,
+        duration: Math.max(
+          1,
+          (grouped[index + 1]?.start ?? segment.start + 5) - segment.start,
+        ),
+        text: segment.text,
+      }));
+      ytdCaptionsState.translations = new Array(
+        ytdCaptionsState.pages.length,
+      ).fill("");
+      bindCaptionsTimeUpdate();
+      showCaptionsOverlay();
+      handleCaptionsTimeUpdate();
+    } else {
+      showCaptionsError(result?.message || "No subtitles available for this video.");
+    }
+  } catch (_error) {
+    if (generation === ytdCaptionsState.generation) {
+      showCaptionsError("Could not load subtitles. Please try again.");
+    }
+  }
+}
+
+function bindCaptionsTimeUpdate() {
+  if (ytdCaptionsTimeUpdateBound) return;
+  ytdCaptionsTimeUpdateBound = true;
+  // timeupdate does not bubble; capture at the document so the listener
+  // survives YouTube swapping the <video> element during SPA navigation.
+  document.addEventListener("timeupdate", handleCaptionsTimeUpdate, true);
+}
+
+function handleCaptionsTimeUpdate() {
+  if (!ytdCaptionsState.enabled || !ytdCaptionsState.pages.length) return;
+  const video = document.querySelector("video.html5-main-video");
+  if (!video) return;
+  const currentTime = video.currentTime;
+
+  let index = -1;
+  for (let i = 0; i < ytdCaptionsState.pages.length; i++) {
+    const chunk = ytdCaptionsState.pages[i];
+    if (currentTime >= chunk.start && currentTime < chunk.start + chunk.duration) {
+      index = i;
+      break;
+    }
+  }
+  if (index === -1) {
+    for (let i = ytdCaptionsState.pages.length - 1; i >= 0; i--) {
+      if (ytdCaptionsState.pages[i].start <= currentTime) {
+        index = i;
+        break;
+      }
+    }
+  }
+
+  const changed = index !== ytdCaptionsState.currentIndex;
+  ytdCaptionsState.currentIndex = index;
+  updateCaptionsDisplay();
+  if (changed && index >= 0) enqueueCaptionsTranslations(index);
+}
+
+function updateCaptionsDisplay() {
+  if (!ytdCaptionsOverlay || !ytdCaptionsState.enabled) return;
+  const original = ytdCaptionsOverlay.querySelector(".ytd-captions-original");
+  const translated = ytdCaptionsOverlay.querySelector(".ytd-captions-translated");
+  if (!original || !translated) return;
+
+  const index = ytdCaptionsState.currentIndex;
+  if (index < 0 || index >= ytdCaptionsState.pages.length) {
+    ytdCaptionsOverlay.style.opacity = "0";
+    return;
+  }
+
+  original.textContent = ytdCaptionsState.pages[index].text;
+  const translatedText = ytdCaptionsState.translations[index];
+  if (translatedText) {
+    translated.textContent = translatedText;
+    translated.style.display = "block";
+  } else {
+    translated.textContent = "";
+    translated.style.display = "none";
+  }
+  ytdCaptionsOverlay.style.opacity = "1";
+}
+
+function showCaptionsOverlay() {
+  if (ytdCaptionsOverlay) ytdCaptionsOverlay.style.opacity = "1";
+}
+
+function hideCaptionsOverlay() {
+  if (ytdCaptionsOverlay) ytdCaptionsOverlay.style.opacity = "0";
+}
+
+function showCaptionsLoading() {
+  if (!ytdCaptionsOverlay) return;
+  const original = ytdCaptionsOverlay.querySelector(".ytd-captions-original");
+  const translated = ytdCaptionsOverlay.querySelector(".ytd-captions-translated");
+  if (original) original.textContent = "Loading subtitles…";
+  if (translated) translated.style.display = "none";
+  ytdCaptionsOverlay.style.opacity = "1";
+}
+
+function showCaptionsError(message) {
+  if (!ytdCaptionsOverlay) return;
+  const original = ytdCaptionsOverlay.querySelector(".ytd-captions-original");
+  const translated = ytdCaptionsOverlay.querySelector(".ytd-captions-translated");
+  if (original) original.textContent = message;
+  if (translated) translated.style.display = "none";
+  ytdCaptionsOverlay.style.opacity = "1";
+}
+
+function enqueueCaptionsTranslations(aroundIndex) {
+  if (!ytdCaptionsState.pages.length) return;
+  const windowSize = 12;
+  const start = Math.max(0, aroundIndex);
+  const end = Math.min(ytdCaptionsState.pages.length, aroundIndex + windowSize);
+  for (let i = start; i < end; i++) enqueueCaptionsIndex(i);
+  processCaptionsQueue();
+}
+
+function enqueueCaptionsIndex(index) {
+  if (
+    !Number.isInteger(index) ||
+    index < 0 ||
+    index >= ytdCaptionsState.pages.length
+  ) {
+    return;
+  }
+  if (ytdCaptionsState.translations[index]) return;
+  if (ytdCaptionsState.queued.has(index)) return;
+  ytdCaptionsState.queue.push(index);
+  ytdCaptionsState.queued.add(index);
+}
+
+async function processCaptionsQueue() {
+  if (ytdCaptionsState.processing || ytdCaptionsState.queue.length === 0) return;
+  ytdCaptionsState.processing = true;
+  const generation = ytdCaptionsState.generation;
+  try {
+    while (ytdCaptionsState.queue.length && generation === ytdCaptionsState.generation) {
+      const batch = ytdCaptionsState.queue.splice(0, 4);
+      batch.forEach((index) => ytdCaptionsState.queued.delete(index));
+
+      const segments = batch.map((index) => ({
+        id: ytdCaptionsState.pages[index].id,
+        text: ytdCaptionsState.pages[index].text,
+      }));
+
+      try {
+        const result = await chrome.runtime.sendMessage({
+          action: "translateContent",
+          content: { segments },
+          contentType: "transcriptBatch",
+          targetLanguage: "zh",
+          videoTitle: ytdCaptionsState.videoTitle || "",
+        });
+        if (generation !== ytdCaptionsState.generation) break;
+
+        if (result?.success) {
+          const byId = new Map(
+            (result.translatedContent?.segments || []).map((s) => [s.id, s.text]),
+          );
+          batch.forEach((index, batchIndex) => {
+            const text = byId.get(segments[batchIndex].id);
+            if (text) ytdCaptionsState.translations[index] = text;
+          });
+        }
+      } catch (_error) {
+        // Leave this batch untranslated and show the original text only.
+      }
+
+      if (generation !== ytdCaptionsState.generation) break;
+      updateCaptionsDisplay();
+    }
+  } finally {
+    ytdCaptionsState.processing = false;
+    if (ytdCaptionsState.queue.length && generation === ytdCaptionsState.generation) {
+      processCaptionsQueue();
+    }
+  }
+}
+
+function resetCaptionsState() {
+  ytdCaptionsState.generation += 1;
+  ytdCaptionsState.videoId = null;
+  ytdCaptionsState.videoTitle = "";
+  ytdCaptionsState.pages = [];
+  ytdCaptionsState.translations = [];
+  ytdCaptionsState.queue = [];
+  ytdCaptionsState.queued.clear();
+  ytdCaptionsState.currentIndex = -1;
+  clearTimeout(ytdCaptionsToggleTimer);
+  ytdCaptionsToggleTimer = null;
+  hideCaptionsOverlay();
+}

--- a/content.js
+++ b/content.js
@@ -49,6 +49,7 @@ const ytdCaptionsState = {
   processing: false,
   currentIndex: -1,
   generation: 0,
+  failedVideoIds: new Set(), // videos confirmed to have no captions this session
 };
 
 // ============================================================
@@ -1293,6 +1294,14 @@ async function loadBilingualCaptions() {
   const videoId = new URLSearchParams(window.location.search).get("v");
   if (!videoId) return;
 
+  // A previous attempt for this video failed (no captions). Don't re-fetch —
+  // the background caches the failure too, so re-requesting would just waste
+  // a message round-trip and flash the loading state for no result.
+  if (ytdCaptionsState.failedVideoIds.has(videoId)) {
+    showCaptionsError("No subtitles available for this video.");
+    return;
+  }
+
   // Same video already loaded — just reveal and top up translations.
   if (ytdCaptionsState.videoId === videoId && ytdCaptionsState.pages.length) {
     showCaptionsOverlay();
@@ -1346,6 +1355,7 @@ async function loadBilingualCaptions() {
       showCaptionsOverlay();
       handleCaptionsTimeUpdate();
     } else {
+      ytdCaptionsState.failedVideoIds.add(videoId);
       showCaptionsError(result?.message || "No subtitles available for this video.");
     }
   } catch (_error) {
@@ -1522,6 +1532,7 @@ function resetCaptionsState() {
   ytdCaptionsState.queue = [];
   ytdCaptionsState.queued.clear();
   ytdCaptionsState.currentIndex = -1;
+  ytdCaptionsState.failedVideoIds.clear();
   clearTimeout(ytdCaptionsToggleTimer);
   ytdCaptionsToggleTimer = null;
   hideCaptionsOverlay();

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,12 @@
       "matches": ["https://www.youtube.com/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "exclude_matches": ["https://www.youtube.com/*"],
+      "js": ["page-translate.js"],
+      "run_at": "document_idle"
     }
   ],
   "icons": {

--- a/page-translate.js
+++ b/page-translate.js
@@ -1,0 +1,179 @@
+/**
+ * PAGE TRANSLATE CONTENT SCRIPT
+ *
+ * Runs on ordinary web pages and translates selected text in a small popup.
+ * YouTube-specific UI stays in content.js.
+ */
+
+const PAGE_TRANSLATE_MAX_SELECTION_CHARS = 4000;
+const PAGE_TRANSLATE_POPUP_ID = "ytd-page-translate-popup";
+
+let pageTranslatePopup = null;
+let pageTranslatePopupContent = null;
+let pageTranslateRequestId = 0;
+
+function getSelectedPageText() {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return { text: "", rect: null };
+  }
+
+  const text = selection.toString().trim();
+  if (!text) return { text: "", rect: null };
+
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+  if (!rect || (rect.width === 0 && rect.height === 0)) {
+    return { text: "", rect: null };
+  }
+
+  return { text, rect };
+}
+
+function ensurePageTranslatePopup() {
+  if (pageTranslatePopup?.isConnected) return pageTranslatePopup;
+
+  const host = document.createElement("div");
+  host.id = PAGE_TRANSLATE_POPUP_ID;
+  host.style.position = "fixed";
+  host.style.zIndex = "2147483647";
+  host.style.display = "none";
+  host.style.left = "0";
+  host.style.top = "0";
+
+  const shadow = host.attachShadow({ mode: "closed" });
+  shadow.innerHTML = `
+    <style>
+      :host {
+        all: initial;
+        color-scheme: light;
+      }
+      .card {
+        box-sizing: border-box;
+        width: min(340px, calc(100vw - 24px));
+        max-height: min(260px, calc(100vh - 24px));
+        overflow: auto;
+        padding: 12px 14px;
+        border: 1px solid rgba(43, 38, 32, 0.14);
+        border-radius: 10px;
+        background: #fffaf3;
+        color: #2f2a24;
+        box-shadow: 0 14px 34px rgba(31, 27, 22, 0.22);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 14px;
+        line-height: 1.55;
+      }
+      .status {
+        color: #7a7066;
+        font-size: 13px;
+      }
+      .error {
+        color: #b0442e;
+        font-size: 13px;
+      }
+      .text {
+        white-space: pre-wrap;
+      }
+    </style>
+    <div class="card" role="status" aria-live="polite">
+      <div class="status" id="content">Translating...</div>
+    </div>
+  `;
+
+  pageTranslatePopup = host;
+  pageTranslatePopupContent = shadow.getElementById("content");
+  document.documentElement.appendChild(host);
+  host.addEventListener("mousedown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  return host;
+}
+
+function positionPageTranslatePopup(rect) {
+  const popup = ensurePageTranslatePopup();
+  popup.style.display = "block";
+
+  const margin = 12;
+  const desiredTop = rect.bottom + 8;
+  const desiredLeft = rect.left + rect.width / 2 - 170;
+  const maxLeft = window.innerWidth - 340 - margin;
+  const left = Math.max(margin, Math.min(desiredLeft, Math.max(margin, maxLeft)));
+  const top = Math.max(
+    margin,
+    Math.min(desiredTop, window.innerHeight - 260 - margin),
+  );
+
+  popup.style.left = `${left}px`;
+  popup.style.top = `${top}px`;
+}
+
+function setPageTranslatePopupContent(text, state = "text") {
+  ensurePageTranslatePopup();
+  if (!pageTranslatePopupContent) return;
+  pageTranslatePopupContent.className = state;
+  pageTranslatePopupContent.textContent = text;
+}
+
+function hidePageTranslatePopup() {
+  pageTranslateRequestId += 1;
+  if (pageTranslatePopup) pageTranslatePopup.style.display = "none";
+}
+
+async function translatePageSelection(text) {
+  const result = await chrome.runtime.sendMessage({
+    action: "translateContent",
+    content: { text },
+    contentType: "selectedText",
+    targetLanguage: "zh",
+    videoTitle: document.title || "Web page",
+  });
+
+  if (!result?.success) {
+    throw new Error(result?.error || "Translation failed.");
+  }
+
+  const translatedText = result.translatedContent?.text?.trim();
+  if (!translatedText) {
+    throw new Error("Translation returned empty text.");
+  }
+  return translatedText;
+}
+
+function handlePageSelectionMouseup(event) {
+  if (pageTranslatePopup?.contains(event.target)) return;
+
+  setTimeout(async () => {
+    const { text, rect } = getSelectedPageText();
+    if (!text || !rect) {
+      hidePageTranslatePopup();
+      return;
+    }
+
+    const requestId = ++pageTranslateRequestId;
+    positionPageTranslatePopup(rect);
+
+    if (text.length > PAGE_TRANSLATE_MAX_SELECTION_CHARS) {
+      setPageTranslatePopupContent("Selected text is too long.", "error");
+      return;
+    }
+
+    setPageTranslatePopupContent("Translating...", "status");
+    try {
+      const translatedText = await translatePageSelection(text);
+      if (requestId !== pageTranslateRequestId) return;
+      setPageTranslatePopupContent(translatedText, "text");
+    } catch (error) {
+      if (requestId !== pageTranslateRequestId) return;
+      setPageTranslatePopupContent(error.message || "Translation failed.", "error");
+    }
+  }, 0);
+}
+
+document.addEventListener("mouseup", handlePageSelectionMouseup);
+document.addEventListener("selectionchange", () => {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) hidePageTranslatePopup();
+});
+window.addEventListener("scroll", hidePageTranslatePopup, true);
+window.addEventListener("resize", hidePageTranslatePopup);

--- a/page-translate.js
+++ b/page-translate.js
@@ -6,11 +6,17 @@
  */
 
 const PAGE_TRANSLATE_MAX_SELECTION_CHARS = 4000;
+const PAGE_TRANSLATE_DEBOUNCE_MS = 300;
 const PAGE_TRANSLATE_POPUP_ID = "ytd-page-translate-popup";
 
 let pageTranslatePopup = null;
 let pageTranslatePopupContent = null;
 let pageTranslateRequestId = 0;
+// Session-level cache of successful translations: selected text -> translated
+// text. Re-selecting the same phrase shows the cached result with zero API
+// cost. Failures are intentionally NOT cached so a retry still works.
+const pageTranslateCache = new Map();
+let pageTranslateDebounceTimer = null;
 
 function getSelectedPageText() {
   const selection = window.getSelection();
@@ -117,10 +123,20 @@ function setPageTranslatePopupContent(text, state = "text") {
 
 function hidePageTranslatePopup() {
   pageTranslateRequestId += 1;
+  clearTimeout(pageTranslateDebounceTimer);
+  pageTranslateDebounceTimer = null;
   if (pageTranslatePopup) pageTranslatePopup.style.display = "none";
 }
 
 async function translatePageSelection(text) {
+  // chrome.runtime can be briefly unavailable (extension reload, sandboxed
+  // contexts, etc.). Without this guard, the raw
+  // "Cannot read properties of undefined (reading 'sendMessage')" leaks to
+  // the popup and tells the user nothing actionable.
+  if (!chrome?.runtime?.sendMessage) {
+    throw new Error("Extension context unavailable. Try reloading the page.");
+  }
+
   const result = await chrome.runtime.sendMessage({
     action: "translateContent",
     content: { text },
@@ -143,31 +159,47 @@ async function translatePageSelection(text) {
 function handlePageSelectionMouseup(event) {
   if (pageTranslatePopup?.contains(event.target)) return;
 
-  setTimeout(async () => {
-    const { text, rect } = getSelectedPageText();
-    if (!text || !rect) {
-      hidePageTranslatePopup();
-      return;
-    }
+  // Debounce: adjusting a selection or re-grabbing text fires many mouseup
+  // events for the same translation need. Collapse them into one request.
+  clearTimeout(pageTranslateDebounceTimer);
+  pageTranslateDebounceTimer = setTimeout(() => {
+    pageTranslateDebounceTimer = null;
+    void handlePageSelectionDebounced();
+  }, PAGE_TRANSLATE_DEBOUNCE_MS);
+}
 
-    const requestId = ++pageTranslateRequestId;
-    positionPageTranslatePopup(rect);
+async function handlePageSelectionDebounced() {
+  const { text, rect } = getSelectedPageText();
+  if (!text || !rect) {
+    hidePageTranslatePopup();
+    return;
+  }
 
-    if (text.length > PAGE_TRANSLATE_MAX_SELECTION_CHARS) {
-      setPageTranslatePopupContent("Selected text is too long.", "error");
-      return;
-    }
+  const requestId = ++pageTranslateRequestId;
+  positionPageTranslatePopup(rect);
 
-    setPageTranslatePopupContent("Translating...", "status");
-    try {
-      const translatedText = await translatePageSelection(text);
-      if (requestId !== pageTranslateRequestId) return;
-      setPageTranslatePopupContent(translatedText, "text");
-    } catch (error) {
-      if (requestId !== pageTranslateRequestId) return;
-      setPageTranslatePopupContent(error.message || "Translation failed.", "error");
-    }
-  }, 0);
+  if (text.length > PAGE_TRANSLATE_MAX_SELECTION_CHARS) {
+    setPageTranslatePopupContent("Selected text is too long.", "error");
+    return;
+  }
+
+  // Cache hit: show the previous translation without spending another request.
+  const cached = pageTranslateCache.get(text);
+  if (cached !== undefined) {
+    setPageTranslatePopupContent(cached, "text");
+    return;
+  }
+
+  setPageTranslatePopupContent("Translating...", "status");
+  try {
+    const translatedText = await translatePageSelection(text);
+    if (requestId !== pageTranslateRequestId) return;
+    pageTranslateCache.set(text, translatedText);
+    setPageTranslatePopupContent(translatedText, "text");
+  } catch (error) {
+    if (requestId !== pageTranslateRequestId) return;
+    setPageTranslatePopupContent(error.message || "Translation failed.", "error");
+  }
 }
 
 document.addEventListener("mouseup", handlePageSelectionMouseup);

--- a/prompts/translation.md
+++ b/prompts/translation.md
@@ -43,6 +43,21 @@ The video is titled "{videoTitle}". Use the title and neighboring segments only 
 - Output only valid JSON. No markdown fences, commentary, labels, or extra keys.
 ```
 
+## Selected text translation
+
+Input is text selected by the user from the current video transcript.
+
+```
+You are a professional translator. Translate the selected transcript text into {langName}.
+The video is titled "{videoTitle}". Use the title only as context for names, pronouns, terminology, and the speaker's intended meaning.
+
+{baseRules}
+
+- Translate the selected text directly and completely.
+- Keep the result concise and easy to read in a small popup.
+- Do not add explanations, labels, quote marks, or markdown fences.
+```
+
 ## Variables
 
 - `{langName}` — "Simplified Chinese".

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -29,6 +29,7 @@ public_allowlist=(
   "background.js"
   "settings.js"
   "content.js"
+  "page-translate.js"
   "sidepanel.html"
   "sidepanel.css"
   "sidepanel.js"

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -42,6 +42,7 @@ let transcriptScrollObserver = null;
 // Stable keys include the video, source mode, language, and semantic segment ID.
 let transcriptParagraphCache = new Map();
 const TRANSLATION_MESSAGE_TIMEOUT_MS = 130_000;
+let selectionFeatureCleanup = null;
 
 /**
  * Prevent a stopped service worker or dead message channel from leaving the
@@ -1232,6 +1233,11 @@ function setupExplainFeature() {
   const transcriptList = document.getElementById("transcriptList");
   if (!transcriptList) return;
 
+  if (selectionFeatureCleanup) {
+    selectionFeatureCleanup();
+    selectionFeatureCleanup = null;
+  }
+
   // Remove existing tooltip if any
   const existingTooltip = document.getElementById("explainTooltip");
   if (existingTooltip) existingTooltip.remove();
@@ -1240,7 +1246,7 @@ function setupExplainFeature() {
   const tooltip = document.createElement("div");
   tooltip.id = "explainTooltip";
   tooltip.className = "explain-tooltip";
-  tooltip.innerHTML = `<button class="explain-btn">💡 Explain</button>`;
+  tooltip.innerHTML = `<button class="explain-btn">Explain</button>`;
   tooltip.style.display = "none";
   document.body.appendChild(tooltip);
 
@@ -1260,7 +1266,7 @@ function setupExplainFeature() {
   });
 
   // Listen for text selection
-  document.addEventListener("mouseup", (e) => {
+  const handleSelectionMouseup = () => {
     const selection = window.getSelection();
     const text = selection.toString().trim();
 
@@ -1281,14 +1287,16 @@ function setupExplainFeature() {
     } else {
       tooltip.style.display = "none";
     }
-  });
+  };
+  document.addEventListener("mouseup", handleSelectionMouseup);
 
   // Hide tooltip when clicking elsewhere
-  document.addEventListener("mousedown", (e) => {
+  const handleDocumentMousedown = (e) => {
     if (!tooltip.contains(e.target)) {
       tooltip.style.display = "none";
     }
-  });
+  };
+  document.addEventListener("mousedown", handleDocumentMousedown);
 
   // Handle explain button click
   tooltip
@@ -1301,6 +1309,12 @@ function setupExplainFeature() {
       tooltip.style.display = "none";
       await showExplanation(selectedText);
     });
+
+  selectionFeatureCleanup = () => {
+    document.removeEventListener("mouseup", handleSelectionMouseup);
+    document.removeEventListener("mousedown", handleDocumentMousedown);
+    tooltip.remove();
+  };
 }
 
 /**

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -32,6 +32,9 @@ let errorAction = null;
 // --- Translation state ---
 // The public transcript control intentionally supports only the original
 // subtitles, Chinese, and an aligned source + Chinese view.
+const TRANSCRIPT_MODE_STORAGE_KEY = "ytd_transcript_mode";
+const TRANSCRIPT_VIEW_STATE_STORAGE_KEY = "ytd_transcript_view_state";
+const TRANSCRIPT_MODES = new Set(["original", "zh", "bilingual"]);
 let currentTranscriptMode = "original";
 let translationGeneration = 0; // Invalidates responses from older UI modes/videos.
 let translationWorkCount = 0;
@@ -83,7 +86,10 @@ function sendTranslationMessage(message) {
 // --- Auto-scroll state (follow video playback in transcript) ---
 let autoScrollEnabled = true; // True = scroll transcript to follow video playback
 let autoScrollInterval = null; // setInterval ID for polling video time
-let lastAutoScrollTime = 0; // Timestamp of last programmatic scroll (ignores scroll events within 1s)
+let programmaticTranscriptScroll = false;
+let programmaticTranscriptScrollTimer = null;
+let restoreTranscriptScrollTimer = null;
+let transcriptViewStateSaveTimer = null;
 
 // ============================================================
 // TRANSCRIPT GROUPING
@@ -231,6 +237,7 @@ function groupTranscriptEntries(entries, limits = TRANSCRIPT_SEGMENT_LIMITS) {
 
 document.addEventListener("DOMContentLoaded", async () => {
   setupEventListeners();
+  await restoreTranscriptMode();
   await evictOldCacheEntries(20);
 
   const configStatus = await chrome.runtime.sendMessage({
@@ -248,6 +255,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 // Listen for messages from the Digest button on YouTube page
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "startDigestFromButton") {
+    if (Number.isInteger(message.tabId)) youtubeTabId = message.tabId;
     // Load the digest for the current video. Served from cache when we've
     // seen this video before (no API calls); fetched fresh otherwise.
     // (This used to force-clear the cache on every click, which silently
@@ -314,26 +322,36 @@ function panelIsShowingResults() {
  * Reacts to the URL now in front of the panel: close on non-YouTube,
  * refresh the digest when the video changed.
  */
-function handleFrontTabUrl(url) {
+function handleFrontTab(tab) {
+  const url = tab?.url || tab?.pendingUrl || "";
   if (!(url || "").startsWith("https://www.youtube.com")) {
     // Panel is a YouTube-only tool — remove itself from non-YouTube tabs.
     window.close();
     return;
   }
 
+  if (Number.isInteger(tab?.id)) youtubeTabId = tab.id;
+
   const newVideoId = extractVideoId(url);
   // Refresh when the video changed, or when we're not currently showing
   // results (e.g. user went home, then clicked back into the same video).
   if (newVideoId !== currentVideoId || !panelIsShowingResults()) {
     scheduleDigestRefresh();
+    return;
   }
+
+  // Same video, different/front tab: do not rebuild the transcript, but do
+  // immediately re-bind Follow playback to the tab the user is actually
+  // looking at. This fixes the common multi-tab case where Chrome recreates
+  // the side panel and the transcript falls back to an old saved position.
+  playbackTrackingTick(true);
 }
 
 // Fires when a tab's URL changes — including YouTube's no-reload navigation.
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (!changeInfo.url || !tab.active) return;
   if (panelWindowId !== null && tab.windowId !== panelWindowId) return;
-  handleFrontTabUrl(changeInfo.url);
+  handleFrontTab({ ...tab, id: tabId, url: changeInfo.url });
 });
 
 // Fires when a different tab comes to the front — switching tabs, or a new
@@ -344,7 +362,7 @@ chrome.tabs.onActivated.addListener(async ({ tabId, windowId }) => {
     const tab = await chrome.tabs.get(tabId);
     // Brand-new tabs may not have committed their URL yet — fall back to
     // the pending one so we judge where the tab is actually going.
-    handleFrontTabUrl(tab.url || tab.pendingUrl || "");
+    handleFrontTab(tab);
   } catch (e) {
     // Tab closed before we could read it — nothing to do.
   }
@@ -387,16 +405,15 @@ function setupEventListeners() {
   // Follow playback button — re-enables auto-scroll after user scrolled away
   document
     .getElementById("followPlaybackBtn")
-    ?.addEventListener("click", () => {
+    ?.addEventListener("click", async () => {
       autoScrollEnabled = true;
       document.getElementById("followPlaybackBtn").style.display = "none";
-      // Jump straight back to the line currently being spoken. We scroll
-      // directly (not via playbackTrackingTick) because the tick skips
-      // entries that are already highlighted — and the current line almost
-      // always IS highlighted, which made this button appear to do nothing.
-      if (!scrollToActiveEntry()) {
-        playbackTrackingTick(); // No highlight yet — let a tick establish one
-      }
+      // The old highlighted line can be several sentences behind after the
+      // reader has scrolled away. Refresh the actual player time before
+      // scrolling, rather than jumping back to that stale highlight.
+      const didScroll = await playbackTrackingTick(true);
+      if (!didScroll) scrollToActiveEntry();
+      saveTranscriptViewStateSoon();
     });
 
   // Notes filter buttons
@@ -428,27 +445,37 @@ async function checkCurrentTab() {
     // Try multiple strategies to find the YouTube tab
     let tab = null;
 
-    // Strategy 1: Active tab in last focused window
-    let tabs = await chrome.tabs.query({
-      active: true,
-      lastFocusedWindow: true,
-    });
+    // Strategy 1: Active tab in the browser window this side panel belongs to.
+    // This keeps multiple YouTube tabs from stealing Follow playback from each
+    // other when the panel is recreated after a tab switch.
+    let activeTabQuery = { active: true };
+    if (panelWindowId !== null) activeTabQuery.windowId = panelWindowId;
+    else activeTabQuery.lastFocusedWindow = true;
+
+    let tabs = await chrome.tabs.query(activeTabQuery);
     if (tabs[0]?.url?.includes("youtube.com")) {
       tab = tabs[0];
     }
 
-    // Strategy 2: Any active YouTube tab
+    // Strategy 2: Any active YouTube tab in this same window
     if (!tab) {
-      tabs = await chrome.tabs.query({
+      const activeYouTubeQuery = {
         url: "https://www.youtube.com/*",
         active: true,
-      });
+      };
+      if (panelWindowId !== null) activeYouTubeQuery.windowId = panelWindowId;
+      tabs = await chrome.tabs.query(activeYouTubeQuery);
       if (tabs[0]) tab = tabs[0];
     }
 
-    // Strategy 3: Any YouTube tab (last resort)
+    // Strategy 3: Any YouTube tab in this window (last resort)
     if (!tab) {
-      tabs = await chrome.tabs.query({ url: "https://www.youtube.com/*" });
+      const anyYouTubeQuery = { url: "https://www.youtube.com/*" };
+      if (panelWindowId !== null) anyYouTubeQuery.windowId = panelWindowId;
+      tabs = await chrome.tabs.query(anyYouTubeQuery);
+      if (!tabs[0] && panelWindowId !== null) {
+        tabs = await chrome.tabs.query({ url: "https://www.youtube.com/*" });
+      }
       if (tabs[0]) tab = tabs[0];
     }
 
@@ -468,17 +495,16 @@ async function checkCurrentTab() {
       currentVideoUrl = tab.url;
 
       try {
-        // Route through background script for reliable message passing
         const result = await chrome.runtime.sendMessage({
-          action: "relayToContent",
-          payload: { action: "getVideoInfo" },
+          action: "getVideoInfo",
+          tabId: youtubeTabId,
         });
         debugLog("[YouTube Digest Panel] getVideoInfo result:", result);
-        if (result.success && result.response) {
-          currentVideoTitle = result.response.title || "";
-          currentChannelName = result.response.channelName || "";
-          currentVideoDescription = result.response.description || "";
-          currentVideoDuration = result.response.duration || 0;
+        if (result) {
+          currentVideoTitle = result.title || "";
+          currentChannelName = result.channelName || "";
+          currentVideoDescription = result.description || "";
+          currentVideoDuration = result.duration || 0;
         }
       } catch (e) {
         console.error("[YouTube Digest Panel] getVideoInfo error:", e);
@@ -529,8 +555,11 @@ function extractVideoId(url) {
 
 async function startDigest(videoId, videoUrl) {
   // Check if we already have this video loaded in memory
-  if (videoId === currentVideoId && currentAnalysis) {
+  if (videoId === currentVideoId && currentTranscript) {
     showState("results");
+    renderVideoInfo();
+    startPlaybackTracking({ preserveFollowState: true });
+    if (currentTranscriptMode !== "original") ensureMissingTranscriptTranslations();
     return;
   }
 
@@ -539,6 +568,7 @@ async function startDigest(videoId, videoUrl) {
     translationGeneration += 1;
     if (transcriptScrollObserver) transcriptScrollObserver.disconnect();
     transcriptScrollObserver = null;
+    autoScrollEnabled = true;
   }
 
   // Check cache for this video
@@ -547,6 +577,17 @@ async function startDigest(videoId, videoUrl) {
     debugLog("Loading from cache:", videoId);
     currentVideoId = videoId;
     currentVideoUrl = videoUrl;
+    // YouTube page metadata can be unavailable briefly after navigation. Keep
+    // the live value when present, otherwise restore the title and author that
+    // were saved with this video's digest.
+    currentVideoTitle = chooseVideoMetadata(
+      currentVideoTitle,
+      cached.videoTitle,
+    );
+    currentChannelName = chooseVideoMetadata(
+      currentChannelName,
+      cached.channelName,
+    );
     currentAnalysis = cached.analysis || null;
     currentTranscript = cached.transcript;
     currentTranscriptText = cached.transcriptText;
@@ -561,12 +602,7 @@ async function startDigest(videoId, videoUrl) {
       }
     }
 
-    if (currentVideoTitle || currentChannelName) {
-      const videoInfo = document.getElementById("videoInfo");
-      document.getElementById("videoTitle").textContent = currentVideoTitle;
-      document.getElementById("videoChannel").textContent = currentChannelName;
-      videoInfo.style.display = "block";
-    }
+    renderVideoInfo();
 
     // Always render transcript first
     renderTranscript();
@@ -598,12 +634,7 @@ async function startDigest(videoId, videoUrl) {
   currentTranscriptLanguage = null;
   isAnalysisLoading = false;
 
-  if (currentVideoTitle || currentChannelName) {
-    const videoInfo = document.getElementById("videoInfo");
-    document.getElementById("videoTitle").textContent = currentVideoTitle;
-    document.getElementById("videoChannel").textContent = currentChannelName;
-    videoInfo.style.display = "block";
-  }
+  renderVideoInfo();
 
   showState("loading");
   updateLoading("Fetching transcript", "");
@@ -655,6 +686,22 @@ async function startDigest(videoId, videoUrl) {
 // ============================================================
 // RENDERING
 // ============================================================
+
+function chooseVideoMetadata(liveValue, cachedValue) {
+  return String(liveValue || cachedValue || "").trim();
+}
+
+function renderVideoInfo() {
+  const videoInfo = document.getElementById("videoInfo");
+  const videoTitle = document.getElementById("videoTitle");
+  const videoChannel = document.getElementById("videoChannel");
+  if (!videoInfo || !videoTitle || !videoChannel) return;
+
+  videoTitle.textContent = currentVideoTitle;
+  videoChannel.textContent = currentChannelName;
+  videoInfo.style.display =
+    currentVideoTitle || currentChannelName ? "block" : "none";
+}
 
 /**
  * Renders the analysis results into the Overview tab.
@@ -865,8 +912,7 @@ function renderTranscript() {
     transcriptList.appendChild(div);
   });
 
-  // Start tracking video playback for auto-scroll
-  startPlaybackTracking();
+  if (currentTranscriptMode === "original") activateTranscriptAfterRender();
 }
 
 function copyTranscript() {
@@ -967,9 +1013,10 @@ function switchTab(tabName) {
 
   // Start/stop playback tracking based on which tab is active
   if (tabName === "transcript") {
-    startPlaybackTracking();
+    startPlaybackTracking({ preserveFollowState: true });
   } else {
-    stopPlaybackTracking();
+    saveTranscriptViewStateSoon();
+    stopPlaybackTracking({ resetFollowState: false });
   }
 
   // Lazy-load LLM analysis when user switches to Overview tab
@@ -1065,6 +1112,7 @@ async function seekTo(seconds) {
     // Fallback: route through background script
     const result = await chrome.runtime.sendMessage({
       action: "relayToContent",
+      tabId: youtubeTabId,
       payload,
     });
     debugLog("[YouTube Digest Panel] seekTo relay result:", result);
@@ -1096,6 +1144,7 @@ async function highlightMomentsOnPage(moments) {
     // Route through background script for reliable message passing
     await chrome.runtime.sendMessage({
       action: "relayToContent",
+      tabId: youtubeTabId,
       payload: {
         action: "highlightMoments",
         moments: moments,
@@ -1596,35 +1645,54 @@ async function deleteNote(noteId) {
  * Starts polling the video's current time and highlighting/scrolling
  * to the matching transcript entry.
  */
-function startPlaybackTracking() {
+function startPlaybackTracking({ preserveFollowState = false } = {}) {
   if (!currentTranscript || !currentTranscript.length) return;
 
   // Don't restart if already tracking (preserves user's auto-scroll state)
   if (autoScrollInterval) return;
 
-  autoScrollEnabled = true;
-  document.getElementById("followPlaybackBtn").style.display = "none";
+  if (!preserveFollowState) autoScrollEnabled = true;
+  document.getElementById("followPlaybackBtn").style.display = autoScrollEnabled
+    ? "none"
+    : "block";
 
   // Poll video time every 500ms
   autoScrollInterval = setInterval(() => playbackTrackingTick(), 500);
+  // Do not make the user wait for the first polling interval before the
+  // current subtitle is highlighted and available to the follow button.
+  playbackTrackingTick(true);
 
-  // Listen for manual scrolls on the content area
+  // A plain scroll event cannot tell user movement from scrollIntoView().
+  // Track the full lifetime of our smooth scroll and separately listen for
+  // explicit user input so programmatic movement never disables following.
   const contentArea = document.getElementById("contentArea");
   contentArea.removeEventListener("scroll", onContentAreaScroll);
   contentArea.addEventListener("scroll", onContentAreaScroll);
+  contentArea.removeEventListener("scrollend", onContentAreaScrollEnd);
+  contentArea.addEventListener("scrollend", onContentAreaScrollEnd);
+  contentArea.removeEventListener("wheel", onManualTranscriptNavigation);
+  contentArea.addEventListener("wheel", onManualTranscriptNavigation, {
+    passive: true,
+  });
+  contentArea.removeEventListener("touchstart", onManualTranscriptNavigation);
+  contentArea.addEventListener("touchstart", onManualTranscriptNavigation, {
+    passive: true,
+  });
+  contentArea.removeEventListener("pointerdown", onTranscriptPointerDown);
+  contentArea.addEventListener("pointerdown", onTranscriptPointerDown);
 }
 
 /**
  * Stops playback tracking entirely. Called when leaving transcript tab,
  * starting a new digest, or leaving results state.
  */
-function stopPlaybackTracking() {
+function stopPlaybackTracking({ resetFollowState = true } = {}) {
   if (autoScrollInterval) {
     clearInterval(autoScrollInterval);
     autoScrollInterval = null;
   }
-  autoScrollEnabled = true; // Reset for next time
-  lastAutoScrollTime = 0;
+  if (resetFollowState) autoScrollEnabled = true; // Reset for next video/state
+  finishProgrammaticTranscriptScroll();
   document.getElementById("followPlaybackBtn").style.display = "none";
 
   // Remove active highlights
@@ -1635,32 +1703,56 @@ function stopPlaybackTracking() {
     });
 }
 
+async function activateTranscriptAfterRender() {
+  await restoreTranscriptViewStateAfterRender();
+  startPlaybackTracking({ preserveFollowState: true });
+}
+
 /**
  * One tick of the playback tracker. Gets current video time from the
  * YouTube tab and highlights + scrolls to the matching transcript entry.
  */
-async function playbackTrackingTick() {
+async function playbackTrackingTick(forceScroll = false) {
   try {
-    const result = await chrome.runtime.sendMessage({
-      action: "relayToContent",
-      payload: { action: "getCurrentTime" },
-    });
+    const playbackState = await getPlaybackState();
+    if (!playbackState) return false;
 
-    if (!result.success || !result.response) return;
-
-    const currentTime = result.response.currentTime || 0;
-    highlightActiveEntry(currentTime);
+    const currentTime = playbackState.currentTime || 0;
+    return highlightActiveEntry(currentTime, forceScroll);
   } catch (error) {
     // Silently ignore — YouTube tab might be closed or navigated away
+    return false;
   }
+}
+
+/**
+ * Read from the exact YouTube tab selected for this side panel. Asking the
+ * background to locate an active tab can pick a different browser tab after a
+ * tab switch, leaving Follow playback with no usable position to follow.
+ */
+async function getPlaybackState() {
+  const payload = { action: "getCurrentTime" };
+
+  if (Number.isInteger(youtubeTabId)) {
+    try {
+      return await chrome.tabs.sendMessage(youtubeTabId, payload);
+    } catch (error) {
+      debugLog("[YouTube Digest Panel] Direct playback lookup failed:", error);
+    }
+  }
+
+  const result = await chrome.runtime.sendMessage({
+    action: "relayToContent",
+    tabId: youtubeTabId,
+    payload,
+  });
+  return result?.success ? result.response : null;
 }
 
 /**
  * Scrolls the transcript to the entry currently being spoken (the one
  * carrying the active-playback highlight). Returns false if nothing is
- * highlighted yet. Stamps lastAutoScrollTime BEFORE scrolling so the scroll
- * events from our own smooth animation aren't mistaken for the user
- * scrolling away (which would re-disable auto-scroll immediately).
+ * highlighted yet.
  */
 function scrollToActiveEntry() {
   const activeEntry = document.querySelector(
@@ -1668,9 +1760,60 @@ function scrollToActiveEntry() {
   );
   if (!activeEntry) return false;
 
-  lastAutoScrollTime = Date.now();
-  activeEntry.scrollIntoView({ behavior: "smooth", block: "center" });
+  scrollTranscriptEntryIntoView(activeEntry);
   return true;
+}
+
+function findTranscriptEntryForTime(entries, currentSeconds) {
+  let activeEntry = null;
+  entries.forEach((entry, index) => {
+    const entrySeconds = parseTranscriptEntrySeconds(entry);
+    const nextEntry = entries[index + 1];
+    const nextSeconds = nextEntry
+      ? parseTranscriptEntrySeconds(nextEntry)
+      : Infinity;
+
+    if (currentSeconds >= entrySeconds && currentSeconds < nextSeconds) {
+      activeEntry = entry;
+    }
+  });
+  return activeEntry;
+}
+
+function parseTranscriptEntrySeconds(entry) {
+  const seconds = Number(entry?.dataset?.seconds);
+  return Number.isFinite(seconds) ? seconds : 0;
+}
+
+function beginProgrammaticTranscriptScroll() {
+  programmaticTranscriptScroll = true;
+  if (programmaticTranscriptScrollTimer) {
+    clearTimeout(programmaticTranscriptScrollTimer);
+  }
+  // Chrome supports scrollend, but keep a safety reset for interrupted
+  // animations and older environments.
+  programmaticTranscriptScrollTimer = setTimeout(
+    finishProgrammaticTranscriptScroll,
+    5000,
+  );
+}
+
+function finishProgrammaticTranscriptScroll() {
+  programmaticTranscriptScroll = false;
+  if (programmaticTranscriptScrollTimer) {
+    clearTimeout(programmaticTranscriptScrollTimer);
+    programmaticTranscriptScrollTimer = null;
+  }
+}
+
+function getTranscriptScrollGuardState() {
+  return { programmatic: programmaticTranscriptScroll };
+}
+
+function scrollTranscriptEntryIntoView(entry) {
+  if (!entry) return;
+  beginProgrammaticTranscriptScroll();
+  entry.scrollIntoView({ behavior: "smooth", block: "center" });
 }
 
 /**
@@ -1679,31 +1822,28 @@ function scrollToActiveEntry() {
  *
  * @param {number} currentSeconds - Current video playback time in seconds
  */
-function highlightActiveEntry(currentSeconds) {
+function highlightActiveEntry(currentSeconds, forceScroll = false) {
   const transcriptList = document.getElementById("transcriptList");
-  if (!transcriptList) return;
+  if (!transcriptList) return false;
 
   const entries = transcriptList.querySelectorAll(".transcript-entry");
-  if (entries.length === 0) return;
+  if (entries.length === 0) return false;
 
   // Find the entry whose time range contains the current playback time
-  let activeEntry = null;
-  entries.forEach((entry, index) => {
-    const entrySeconds = parseInt(entry.dataset.seconds);
-    const nextEntry = entries[index + 1];
-    const nextSeconds = nextEntry
-      ? parseInt(nextEntry.dataset.seconds)
-      : Infinity;
+  const activeEntry = findTranscriptEntryForTime(entries, currentSeconds);
 
-    if (currentSeconds >= entrySeconds && currentSeconds < nextSeconds) {
-      activeEntry = entry;
+  if (!activeEntry) return false;
+
+  // Usually nothing needs updating when the same line remains active. A user
+  // who explicitly resumes Follow playback is the exception: force one scroll
+  // to the freshly confirmed current line.
+  if (activeEntry.classList.contains("active-playback")) {
+    if (forceScroll && autoScrollEnabled) {
+      scrollTranscriptEntryIntoView(activeEntry);
+      return true;
     }
-  });
-
-  if (!activeEntry) return;
-
-  // Skip if this entry is already highlighted (no DOM thrashing)
-  if (activeEntry.classList.contains("active-playback")) return;
+    return false;
+  }
 
   // Remove old highlight, add new one
   entries.forEach((e) => e.classList.remove("active-playback"));
@@ -1711,9 +1851,10 @@ function highlightActiveEntry(currentSeconds) {
 
   // Only scroll if auto-scroll is enabled
   if (autoScrollEnabled) {
-    lastAutoScrollTime = Date.now();
-    activeEntry.scrollIntoView({ behavior: "smooth", block: "center" });
+    scrollTranscriptEntryIntoView(activeEntry);
+    return true;
   }
+  return false;
 }
 
 /**
@@ -1722,14 +1863,35 @@ function highlightActiveEntry(currentSeconds) {
  * can read at their own pace without being yanked back.
  */
 function onContentAreaScroll() {
-  // Ignore scroll events within 1 second of a programmatic scroll
-  // (smooth scroll animations can last longer than a simple boolean flag)
-  if (Date.now() - lastAutoScrollTime < 1000) return;
+  if (programmaticTranscriptScroll) return;
 
-  // User scrolled manually — disable auto-scroll and show the button
+  disableAutoScrollForManualNavigation();
+  saveTranscriptViewStateSoon();
+}
+
+function onContentAreaScrollEnd() {
+  if (programmaticTranscriptScroll) finishProgrammaticTranscriptScroll();
+  saveTranscriptViewStateSoon();
+}
+
+function onManualTranscriptNavigation() {
+  // Wheel/touch input must win even if it interrupts an in-flight smooth
+  // scroll. The following scroll event will then remain classified as manual.
+  finishProgrammaticTranscriptScroll();
+  disableAutoScrollForManualNavigation();
+}
+
+function onTranscriptPointerDown(event) {
+  // A scrollbar drag targets the scroll container itself. Clicks on transcript
+  // rows keep their normal seek/select behavior and do not pause following.
+  if (event.target === event.currentTarget) onManualTranscriptNavigation();
+}
+
+function disableAutoScrollForManualNavigation() {
   if (autoScrollEnabled && autoScrollInterval) {
     autoScrollEnabled = false;
     document.getElementById("followPlaybackBtn").style.display = "block";
+    saveTranscriptViewStateSoon();
   }
 }
 
@@ -1742,6 +1904,114 @@ function getOriginalTranscriptLabel() {
   return /^[A-Za-z0-9-]{1,20}$/.test(language)
     ? `Original (${language})`
     : "Original";
+}
+
+function normalizeTranscriptMode(mode) {
+  return TRANSCRIPT_MODES.has(mode) ? mode : "original";
+}
+
+/**
+ * Restores the user's display choice whenever the side panel is recreated.
+ * This is intentionally a global preference: choosing bilingual on one video
+ * should keep that view when returning to YouTube or opening another video.
+ */
+async function restoreTranscriptMode() {
+  try {
+    const stored = await chrome.storage.local.get(TRANSCRIPT_MODE_STORAGE_KEY);
+    currentTranscriptMode = normalizeTranscriptMode(
+      stored[TRANSCRIPT_MODE_STORAGE_KEY],
+    );
+  } catch (error) {
+    console.warn("Could not restore transcript display mode:", error);
+    currentTranscriptMode = "original";
+  }
+  setTranscriptModeButtons(currentTranscriptMode);
+  return currentTranscriptMode;
+}
+
+async function persistTranscriptMode(mode) {
+  const normalizedMode = normalizeTranscriptMode(mode);
+  await chrome.storage.local.set({
+    [TRANSCRIPT_MODE_STORAGE_KEY]: normalizedMode,
+  });
+  return normalizedMode;
+}
+
+function getTranscriptViewStateKey() {
+  if (!currentVideoId) return "";
+  return `${currentVideoId}:${currentTranscriptMode}`;
+}
+
+function setCurrentVideoForTesting(videoId) {
+  currentVideoId = videoId;
+}
+
+async function readStoredTranscriptViewStates() {
+  try {
+    const stored = await chrome.storage.local.get(TRANSCRIPT_VIEW_STATE_STORAGE_KEY);
+    const states = stored[TRANSCRIPT_VIEW_STATE_STORAGE_KEY];
+    return states && typeof states === "object" ? states : {};
+  } catch (error) {
+    console.warn("Could not read transcript scroll state:", error);
+    return {};
+  }
+}
+
+async function saveTranscriptViewState() {
+  const contentArea = document.getElementById("contentArea");
+  const key = getTranscriptViewStateKey();
+  if (!contentArea || !key) return;
+
+  try {
+    const states = await readStoredTranscriptViewStates();
+    states[key] = {
+      scrollTop: contentArea.scrollTop || 0,
+      autoScrollEnabled,
+      updatedAt: Date.now(),
+    };
+    await chrome.storage.local.set({ [TRANSCRIPT_VIEW_STATE_STORAGE_KEY]: states });
+  } catch (error) {
+    console.warn("Could not save transcript scroll state:", error);
+  }
+}
+
+function saveTranscriptViewStateSoon() {
+  if (transcriptViewStateSaveTimer) {
+    clearTimeout(transcriptViewStateSaveTimer);
+  }
+  transcriptViewStateSaveTimer = setTimeout(() => {
+    transcriptViewStateSaveTimer = null;
+    saveTranscriptViewState();
+  }, 150);
+}
+
+async function restoreTranscriptViewStateAfterRender() {
+  const contentArea = document.getElementById("contentArea");
+  const key = getTranscriptViewStateKey();
+  if (!contentArea || !key) return;
+
+  const states = await readStoredTranscriptViewStates();
+  const state = states[key];
+  if (!state || typeof state !== "object") return;
+
+  autoScrollEnabled = state.autoScrollEnabled !== false;
+  const followButton = document.getElementById("followPlaybackBtn");
+  if (followButton) {
+    followButton.style.display = autoScrollEnabled ? "none" : "block";
+  }
+
+  if (autoScrollEnabled) return;
+
+  const scrollTop = Number(state.scrollTop);
+  if (!Number.isFinite(scrollTop) || scrollTop <= 0) return;
+
+  beginProgrammaticTranscriptScroll();
+  contentArea.scrollTop = scrollTop;
+  if (restoreTranscriptScrollTimer) clearTimeout(restoreTranscriptScrollTimer);
+  restoreTranscriptScrollTimer = setTimeout(() => {
+    restoreTranscriptScrollTimer = null;
+    finishProgrammaticTranscriptScroll();
+  }, 50);
 }
 
 function getActiveTranscriptSegments() {
@@ -1761,10 +2031,16 @@ function setTranscriptModeButtons(mode) {
 }
 
 async function handleTranscriptModeChange(mode) {
-  if (!["original", "zh", "bilingual"].includes(mode)) return;
+  if (!TRANSCRIPT_MODES.has(mode)) return;
   if (mode === currentTranscriptMode) return;
 
   currentTranscriptMode = mode;
+  try {
+    await persistTranscriptMode(mode);
+  } catch (error) {
+    // Keep the current view usable even if Chrome storage is temporarily unavailable.
+    console.warn("Could not save transcript display mode:", error);
+  }
   translationGeneration += 1;
   translationWorkCount = 0;
   setTranslatingSpinner(false);
@@ -1841,7 +2117,7 @@ function renderTranscriptModeRows(segments, mode) {
     rows.push(div);
   });
 
-  startPlaybackTracking();
+  activateTranscriptAfterRender();
   return rows;
 }
 
@@ -1988,6 +2264,25 @@ function retryTranslationSegment(index, generation) {
   activeTranslationQueue.enqueue(index, true);
 }
 
+function ensureMissingTranscriptTranslations() {
+  if (currentTranscriptMode === "original") return;
+  if (!activeTranslationQueue) {
+    translateTranscript();
+    return;
+  }
+
+  document
+    .querySelectorAll("#transcriptList .transcript-entry")
+    .forEach((row) => {
+      if (row.classList.contains("translated")) return;
+      const index = Number(row.dataset.segmentIndex);
+      activeTranslationQueue.enqueue(
+        index,
+        row.classList.contains("translation-failed"),
+      );
+    });
+}
+
 /**
  * Renders immediately, translates the first small batch, then observes the
  * remaining rows. Batches are sequential so the provider is never flooded.
@@ -2011,7 +2306,7 @@ async function translateTranscript() {
     if (processing || queue.length === 0 || generation !== translationGeneration)
       return;
     processing = true;
-    const indices = queue.splice(0, 3);
+    const indices = queue.splice(0, 4);
     indices.forEach((index) => queued.delete(index));
     try {
       await requestTranscriptTranslationBatch(
@@ -2061,8 +2356,14 @@ async function translateTranscript() {
 
   rows.forEach((row, index) => {
     if (!row.classList.contains("translated")) transcriptScrollObserver.observe(row);
-    if (index < 3) enqueue(index);
+    if (index < 4) enqueue(index);
   });
+  setTimeout(() => {
+    if (generation !== translationGeneration) return;
+    rows.forEach((row, index) => {
+      if (!row.classList.contains("translated")) enqueue(index);
+    });
+  }, 250);
 }
 
 function setTranslatingSpinner(show) {
@@ -2076,9 +2377,27 @@ function setTranslatingSpinner(show) {
 // Pure helpers are exposed for the repository's Node tests. The extension does
 // not read this object at runtime.
 globalThis.__YTD_TRANSCRIPT_TESTING__ = {
+  TRANSCRIPT_MODE_STORAGE_KEY,
+  TRANSCRIPT_VIEW_STATE_STORAGE_KEY,
+  normalizeTranscriptMode,
+  persistTranscriptMode,
+  restoreTranscriptMode,
+  getTranscriptViewStateKey,
+  __setCurrentVideoForTesting: setCurrentVideoForTesting,
+  saveTranscriptViewState,
+  restoreTranscriptViewStateAfterRender,
+  chooseVideoMetadata,
+  getPlaybackState,
+  findTranscriptEntryForTime,
+  parseTranscriptEntrySeconds,
+  beginProgrammaticTranscriptScroll,
+  finishProgrammaticTranscriptScroll,
+  getTranscriptScrollGuardState,
+  onManualTranscriptNavigation,
   sendTranslationMessage,
   groupTranscriptEntries,
   splitOversizedThought,
+  ensureMissingTranscriptTranslations,
   alignTranslatedSegmentBatch,
   renderSubtitleInlineMarkup,
   renderTranscriptSegmentContent,

--- a/tests/bilingual-captions.test.js
+++ b/tests/bilingual-captions.test.js
@@ -1,0 +1,64 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+
+test("bilingual captions render a player toggle and overlay", () => {
+  const source = read("content.js");
+  assert.match(source, /\.id = "ytd-captions-toggle"/);
+  assert.match(source, /\.id = "ytd-captions-overlay"/);
+  assert.match(
+    source,
+    /document\.getElementById\("ytd-captions-toggle"\)/,
+    "SPA navigation must clean up the toggle",
+  );
+  assert.match(
+    source,
+    /document\.getElementById\("ytd-captions-overlay"\)/,
+    "SPA navigation must clean up the overlay",
+  );
+});
+
+test("bilingual captions reuse the transcript and translation message paths", () => {
+  const source = read("content.js");
+  assert.match(source, /action: "fetchTranscript"/);
+  assert.match(source, /action: "translateContent"/);
+  assert.match(source, /contentType: "transcriptBatch"/);
+  assert.match(source, /targetLanguage: "zh"/);
+});
+
+test("bilingual captions sync to playback and translate in sequential batches", () => {
+  const source = read("content.js");
+  assert.match(
+    source,
+    /document\.addEventListener\("timeupdate", handleCaptionsTimeUpdate, true\)/,
+    "capture-phase listener must survive YouTube swapping the <video> element",
+  );
+  assert.match(source, /\.splice\(0, 4\)/, "translation batches must be capped at 4");
+  assert.match(source, /resetCaptionsState\(\)/);
+});
+
+test("background exposes the captions preference through the service worker", () => {
+  const source = read("background.js");
+  assert.match(source, /message\.action === "getCaptionsPref"/);
+  assert.match(source, /message\.action === "setCaptionsPref"/);
+  assert.match(source, /ytd_captions_enabled/);
+  assert.doesNotMatch(
+    source,
+    /chrome\.storage\.local\.setAccessLevel\(\{ accessLevel: "TRUSTED_AND_UNTRUSTED_CONTEXTS"/,
+    "storage must stay TRUSTED_CONTEXTS so content scripts cannot read API keys",
+  );
+});
+
+test("bilingual captions reuse the side panel's semantic segmentation", () => {
+  const source = read("content.js");
+  assert.match(source, /CAPTIONS_SEGMENT_LIMITS/);
+  assert.match(source, /idealChars: 180/);
+  assert.match(source, /maxChars: 320/);
+  assert.match(source, /function groupCaptionsIntoPages/);
+  assert.match(source, /groupCaptionsIntoPages\(cleanChunks\)/);
+  assert.match(source, /id: ytdCaptionsState\.pages\[index\]\.id/);
+});

--- a/tests/digest-button.test.js
+++ b/tests/digest-button.test.js
@@ -332,3 +332,11 @@ test("DOM mutation reconciliation repairs a replaced toolbar", () => {
   assert.equal(newRow.children.length, 1);
   assert.equal(newGroup.children.length, 1);
 });
+
+test("note keyboard shortcut ignores browser and system modifier keys", () => {
+  assert.match(
+    contentScript,
+    /if \(e\.ctrlKey \|\| e\.metaKey \|\| e\.altKey\) return;/,
+    "Cmd/Ctrl/Alt+N must fall through to the browser instead of saving a note",
+  );
+});

--- a/tests/failed-transcript-cache.test.js
+++ b/tests/failed-transcript-cache.test.js
@@ -1,0 +1,99 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const background = fs.readFileSync(
+  path.resolve(__dirname, "..", "background.js"),
+  "utf8",
+);
+const content = fs.readFileSync(
+  path.resolve(__dirname, "..", "content.js"),
+  "utf8",
+);
+
+test("background caches caption-less failures so the same video is not re-fetched", () => {
+  // 24h TTL constant exists.
+  assert.match(
+    background,
+    /const TRANSCRIPT_FAILURE_CACHE_TTL_MS = 24 \* 60 \* 60 \* 1000;/,
+    "failure cache TTL should be 24 hours",
+  );
+
+  // Failure read/write helpers exist.
+  assert.match(
+    background,
+    /async function readFailedTranscript\(videoId\)[\s\S]*?async function writeFailedTranscript\(videoId, transcriptResult\)/,
+  );
+  assert.match(
+    background,
+    /function failedTranscriptCacheKey\(videoId\)\s*\{\s*return `digest_failed_\$\{videoId\}`;\s*\}/,
+    "failure cache must use a distinct key so it never shadows a real digest",
+  );
+});
+
+test("only video-property errors are cacheable; transient errors are not", () => {
+  assert.match(
+    background,
+    /const TRANSCRIPT_CACHEABLE_ERRORS = new Set\(\[[\s\S]*?"NO_TRANSCRIPT"[\s\S]*?"EMPTY_TRANSCRIPT"[\s\S]*?\]\);/,
+  );
+  // Transient failures must NOT be cached (user should be able to retry).
+  assert.doesNotMatch(
+    background,
+    /TRANSCRIPT_CACHEABLE_ERRORS\s*=\s*new Set\(\[[^\]]*"RATE_LIMITED"/,
+  );
+  assert.doesNotMatch(
+    background,
+    /TRANSCRIPT_CACHEABLE_ERRORS\s*=\s*new Set\(\[[^\]]*"NO_SUPADATA_KEY"/,
+  );
+});
+
+test("handleFetchTranscript consults the failure cache before hitting Supadata", () => {
+  // Order matters: success cache -> failure cache -> in-flight promise -> API.
+  const fnStart = background.indexOf("async function handleFetchTranscript(");
+  const idxSuccessCache = background.indexOf("readCachedTranscript(videoId);", fnStart);
+  const idxFailureCache = background.indexOf("readFailedTranscript(videoId);", idxSuccessCache);
+  const idxInFlight = background.indexOf("transcriptFetchPromises.has(videoId)", idxFailureCache);
+  const idxApi = background.indexOf("fetchTranscriptFromSupadata(videoId)", idxInFlight);
+  assert.ok(
+    idxSuccessCache > fnStart &&
+      idxFailureCache > idxSuccessCache &&
+      idxInFlight > idxFailureCache &&
+      idxApi > idxInFlight,
+    "failure cache must be checked before any Supadata call",
+  );
+
+  // Successful fetches write the success cache; failures write the failure cache.
+  const thenStart = background.indexOf("fetchTranscriptFromSupadata(videoId).then", idxApi);
+  const idxSuccessWrite = background.indexOf("writeCachedTranscript(videoId, result);", thenStart);
+  const idxFailureWrite = background.indexOf("writeFailedTranscript(videoId, result);", idxSuccessWrite);
+  assert.ok(
+    idxSuccessWrite > thenStart && idxFailureWrite > idxSuccessWrite,
+    "fetch result must route to the success or failure cache",
+  );
+});
+
+test("content script marks caption-less videos so it never re-fetches them", () => {
+  assert.match(
+    content,
+    /failedVideoIds: new Set\(\), \/\/ videos confirmed to have no captions this session/,
+  );
+
+  // Checked before the per-video pages guard, so a failed video short-circuits.
+  assert.match(
+    content,
+    /async function loadBilingualCaptions\(\) \{[\s\S]*?if \(ytdCaptionsState\.failedVideoIds\.has\(videoId\)\) \{[\s\S]*?showCaptionsError\([\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(ytdCaptionsState\.videoId === videoId && ytdCaptionsState\.pages\.length\)/,
+  );
+
+  // The failure branch records the video.
+  assert.match(
+    content,
+    /\} else \{\s*ytdCaptionsState\.failedVideoIds\.add\(videoId\);[\s\S]*?showCaptionsError\(result\?\.message/,
+  );
+
+  // resetCaptionsState clears the set so a fresh navigation can try again.
+  assert.match(
+    content,
+    /function resetCaptionsState\(\) \{[\s\S]*?ytdCaptionsState\.failedVideoIds\.clear\(\);/,
+  );
+});

--- a/tests/page-translate.test.js
+++ b/tests/page-translate.test.js
@@ -1,0 +1,30 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+
+test("ordinary web pages receive the selection translation content script", () => {
+  const manifest = JSON.parse(read("manifest.json"));
+  const script = manifest.content_scripts.find((item) =>
+    item.js.includes("page-translate.js")
+  );
+
+  assert.ok(script, "page translation content script must be registered");
+  assert.deepEqual(script.matches, ["http://*/*", "https://*/*"]);
+  assert.deepEqual(script.exclude_matches, ["https://www.youtube.com/*"]);
+  assert.equal(script.run_at, "document_idle");
+});
+
+test("page translation script sends selected text to the translation action", () => {
+  const source = read("page-translate.js");
+
+  assert.match(source, /window\.getSelection\(\)/);
+  assert.match(source, /action: "translateContent"/);
+  assert.match(source, /contentType: "selectedText"/);
+  assert.match(source, /targetLanguage: "zh"/);
+  assert.match(source, /PAGE_TRANSLATE_MAX_SELECTION_CHARS = 4000/);
+  assert.doesNotMatch(source, /youtube\.com/);
+});

--- a/tests/page-translate.test.js
+++ b/tests/page-translate.test.js
@@ -28,3 +28,42 @@ test("page translation script sends selected text to the translation action", ()
   assert.match(source, /PAGE_TRANSLATE_MAX_SELECTION_CHARS = 4000/);
   assert.doesNotMatch(source, /youtube\.com/);
 });
+
+test("page translation debounces rapid selections into a single request", () => {
+  const source = read("page-translate.js");
+
+  assert.match(source, /PAGE_TRANSLATE_DEBOUNCE_MS = 300/);
+  assert.match(source, /setTimeout\([\s\S]*?PAGE_TRANSLATE_DEBOUNCE_MS\)/);
+  // Each mouseup clears the pending timer before scheduling a new one.
+  assert.match(source, /clearTimeout\(pageTranslateDebounceTimer\)[\s\S]*?setTimeout\(/);
+  // Cancelling the selection (hide) also cancels the pending request.
+  assert.match(source, /function hidePageTranslatePopup\(\) \{[\s\S]*?clearTimeout\(pageTranslateDebounceTimer\)/);
+});
+
+test("page translation caches successful results and skips the API on re-select", () => {
+  const source = read("page-translate.js");
+
+  assert.match(source, /const pageTranslateCache = new Map\(\)/);
+  // The API call is only reached after the cache lookup misses.
+  assert.match(
+    source,
+    /pageTranslateCache\.get\(text\)[\s\S]*?if \(cached !== undefined\) \{[\s\S]*?setPageTranslatePopupContent\(cached, "text"\)[\s\S]*?return;[\s\S]*?\}[\s\S]*?translatePageSelection\(text\)/,
+  );
+  // Only successful translations are stored.
+  assert.match(source, /pageTranslateCache\.set\(text, translatedText\)/);
+  // The cache write happens in the try (success) branch, not in catch.
+  assert.match(
+    source,
+    /const translatedText = await translatePageSelection\(text\);[\s\S]*?pageTranslateCache\.set\(text, translatedText\)/,
+  );
+});
+
+test("page translation guards against missing chrome.runtime context", () => {
+  const source = read("page-translate.js");
+
+  // Guard appears inside translatePageSelection, before any sendMessage call.
+  assert.match(
+    source,
+    /async function translatePageSelection\(text\) \{[\s\S]*?if \(!chrome\?\.runtime\?\.sendMessage\) \{[\s\S]*?throw new Error\("Extension context unavailable[\s\S]*?\);[\s\S]*?\}[\s\S]*?await chrome\.runtime\.sendMessage\(/,
+  );
+});

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -17,6 +17,18 @@ test("manifest uses minimized install-time permissions", () => {
   assert.ok(!manifest.permissions.includes("activeTab"));
   assert.ok(manifest.host_permissions.includes("https://api.deepseek.com/*"));
   assert.equal(Object.hasOwn(manifest, "optional_host_permissions"), false);
+  assert.deepEqual(
+    manifest.content_scripts.find((item) =>
+      item.js.includes("page-translate.js")
+    )?.matches,
+    ["http://*/*", "https://*/*"],
+  );
+  assert.deepEqual(
+    manifest.content_scripts.find((item) =>
+      item.js.includes("page-translate.js")
+    )?.exclude_matches,
+    ["https://www.youtube.com/*"],
+  );
   assert.equal(manifest.version, "1.1.5");
 });
 
@@ -248,6 +260,7 @@ test("published prompt files contain runtime sections", () => {
       "Shared base rules",
       "Chinese rules",
       "Transcript batch translation",
+      "Selected text translation",
     ],
   };
 

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -32,6 +32,19 @@ test("manifest uses minimized install-time permissions", () => {
   assert.equal(manifest.version, "1.1.5");
 });
 
+test("Supadata transcript requests are centrally cached and deduplicated", () => {
+  const background = read("background.js");
+
+  assert.match(background, /const transcriptFetchPromises = new Map\(\)/);
+  assert.match(background, /async function readCachedTranscript\(videoId\)/);
+  assert.match(background, /async function writeCachedTranscript\(videoId, transcriptResult\)/);
+  assert.match(background, /if \(transcriptFetchPromises\.has\(videoId\)\)/);
+  assert.match(background, /return transcriptFetchPromises\.get\(videoId\)/);
+  assert.match(background, /fetchTranscriptFromSupadata\(videoId\)/);
+  assert.match(background, /transcriptFetchPromises\.delete\(videoId\)/);
+  assert.match(background, /transcriptTimestamped: transcriptResult\.transcriptTextTimestamped/);
+});
+
 test("release copy documents current scope without em dashes", () => {
   const readme = read("README.md");
   const chineseReadme = read("README.zh-CN.md");

--- a/tests/transcript-selection.test.js
+++ b/tests/transcript-selection.test.js
@@ -37,7 +37,15 @@ test("all timestamped transcript row clicks use the selection-aware seek helper"
   );
 });
 
-test("the Explain tooltip preserves selection and contains pointer events", () => {
+test("the Explain tooltip preserves selection, cleanup, and pointer events", () => {
+  assert.match(
+    source,
+    /if \(selectionFeatureCleanup\) \{[\s\S]*?selectionFeatureCleanup\(\);[\s\S]*?selectionFeatureCleanup = null;/,
+  );
+  assert.match(
+    source,
+    /selectionFeatureCleanup = \(\) => \{[\s\S]*?document\.removeEventListener\("mouseup", handleSelectionMouseup\);[\s\S]*?document\.removeEventListener\("mousedown", handleDocumentMousedown\);[\s\S]*?tooltip\.remove\(\);/,
+  );
   assert.match(
     source,
     /tooltip\.addEventListener\("mousedown", \(event\) => \{\s+event\.preventDefault\(\);\s+event\.stopPropagation\(\);/,

--- a/tests/translation.test.js
+++ b/tests/translation.test.js
@@ -11,8 +11,11 @@ function loadSidepanelHelpers({
   sendMessage = () => Promise.resolve({}),
   setTimeoutImpl = () => 0,
   clearTimeoutImpl = () => {},
+  storedValues = {},
+  documentImpl = null,
 } = {}) {
   const listeners = { addListener() {} };
+  const storage = { ...storedValues };
   const sandbox = {
     console,
     URL,
@@ -25,7 +28,7 @@ function loadSidepanelHelpers({
     IntersectionObserver: class {},
     CSS: { escape: (value) => value },
     window: { getSelection: () => null, close() {} },
-    document: {
+    document: documentImpl || {
       addEventListener() {},
       querySelectorAll: () => [],
       querySelector: () => null,
@@ -47,6 +50,15 @@ function loadSidepanelHelpers({
       },
     },
     chrome: {
+      storage: {
+        local: {
+          get: async (key) => {
+            if (typeof key === "string") return { [key]: storage[key] };
+            return { ...storage };
+          },
+          set: async (items) => Object.assign(storage, items),
+        },
+      },
       runtime: { onMessage: listeners, sendMessage },
       windows: { getCurrent: () => Promise.resolve({ id: 1 }) },
       tabs: { onUpdated: listeners, onActivated: listeners },
@@ -55,7 +67,7 @@ function loadSidepanelHelpers({
   };
   sandbox.globalThis = sandbox;
   vm.runInNewContext(read("sidepanel.js"), sandbox);
-  return sandbox.__YTD_TRANSCRIPT_TESTING__;
+  return { ...sandbox.__YTD_TRANSCRIPT_TESTING__, storage };
 }
 
 function loadBackgroundHelpers({
@@ -177,6 +189,272 @@ test("Transcript header exposes and wires Original, Chinese, and bilingual modes
   assert.match(js, /Original \(\$\{language\}\)/);
 });
 
+test("transcript display mode is restored as a persistent preference", () => {
+  const {
+    normalizeTranscriptMode,
+    TRANSCRIPT_MODE_STORAGE_KEY,
+    persistTranscriptMode,
+    restoreTranscriptMode,
+    storage,
+  } =
+    loadSidepanelHelpers();
+  const js = read("sidepanel.js");
+
+  assert.equal(TRANSCRIPT_MODE_STORAGE_KEY, "ytd_transcript_mode");
+  assert.equal(normalizeTranscriptMode("bilingual"), "bilingual");
+  assert.equal(normalizeTranscriptMode("zh"), "zh");
+  assert.equal(normalizeTranscriptMode("unsupported"), "original");
+  return persistTranscriptMode("bilingual").then(async () => {
+    assert.equal(storage.ytd_transcript_mode, "bilingual");
+    assert.equal(await restoreTranscriptMode(), "bilingual");
+  });
+});
+
+test("transcript mode loads before the panel starts loading a video", () => {
+  const js = read("sidepanel.js");
+  assert.match(
+    js,
+    /await restoreTranscriptMode\(\);[\s\S]*?await evictOldCacheEntries/,
+    "the preference must load before the panel starts loading a video",
+  );
+  assert.match(
+    js,
+    /currentTranscriptMode = mode;[\s\S]*?await persistTranscriptMode\(mode\);/,
+    "a mode change must be saved before later navigation can recreate the panel",
+  );
+});
+
+test("transcript scroll state is restored per video and display mode", async () => {
+  let contentScrollTop = 0;
+  const followButton = { style: { display: "none" } };
+  const timers = createFakeTimers();
+  const sidepanel = loadSidepanelHelpers({
+    storedValues: {
+      ytd_transcript_mode: "bilingual",
+      ytd_transcript_view_state: {
+        "abc123:bilingual": {
+          scrollTop: 480,
+          autoScrollEnabled: false,
+          updatedAt: 1,
+        },
+      },
+    },
+    setTimeoutImpl: timers.setTimeout,
+    clearTimeoutImpl: timers.clearTimeout,
+    documentImpl: {
+      addEventListener() {},
+      querySelectorAll: () => [],
+      querySelector: () => null,
+      getElementById: (id) => {
+        if (id === "contentArea") {
+          return {
+            get scrollTop() {
+              return contentScrollTop;
+            },
+            set scrollTop(value) {
+              contentScrollTop = value;
+            },
+          };
+        }
+        if (id === "followPlaybackBtn") return followButton;
+        return null;
+      },
+      createElement: () => ({ textContent: "", innerHTML: "" }),
+    },
+  });
+
+  await sidepanel.restoreTranscriptMode();
+  sidepanel.__setCurrentVideoForTesting("abc123");
+  await sidepanel.restoreTranscriptViewStateAfterRender();
+
+  assert.equal(contentScrollTop, 480);
+  assert.equal(followButton.style.display, "block");
+  assert.equal(sidepanel.getTranscriptScrollGuardState().programmatic, true);
+  timers.fireActive(50);
+  assert.equal(sidepanel.getTranscriptScrollGuardState().programmatic, false);
+});
+
+test("saved scroll position does not override active Follow playback", async () => {
+  let contentScrollTop = 0;
+  const followButton = { style: { display: "none" } };
+  const sidepanel = loadSidepanelHelpers({
+    storedValues: {
+      ytd_transcript_mode: "bilingual",
+      ytd_transcript_view_state: {
+        "abc123:bilingual": {
+          scrollTop: 480,
+          autoScrollEnabled: true,
+          updatedAt: 1,
+        },
+      },
+    },
+    documentImpl: {
+      addEventListener() {},
+      querySelectorAll: () => [],
+      querySelector: () => null,
+      getElementById: (id) => {
+        if (id === "contentArea") {
+          return {
+            get scrollTop() {
+              return contentScrollTop;
+            },
+            set scrollTop(value) {
+              contentScrollTop = value;
+            },
+          };
+        }
+        if (id === "followPlaybackBtn") return followButton;
+        return null;
+      },
+      createElement: () => ({ textContent: "", innerHTML: "" }),
+    },
+  });
+
+  await sidepanel.restoreTranscriptMode();
+  sidepanel.__setCurrentVideoForTesting("abc123");
+  await sidepanel.restoreTranscriptViewStateAfterRender();
+
+  assert.equal(contentScrollTop, 0);
+  assert.equal(followButton.style.display, "none");
+  assert.equal(sidepanel.getTranscriptScrollGuardState().programmatic, false);
+});
+
+test("same-video tab activation does not rebuild transcript from cache", () => {
+  const js = read("sidepanel.js");
+
+  assert.match(
+    js,
+    /if \(videoId === currentVideoId && currentTranscript\) \{[\s\S]*?return;[\s\S]*?\}/,
+    "returning to an already-loaded video should keep the current transcript DOM",
+  );
+  assert.match(
+    js,
+    /startPlaybackTracking\(\{ preserveFollowState: true \}\)/,
+    "same-video activation must preserve the user's Follow playback choice",
+  );
+  assert.match(
+    js,
+    /function handleFrontTab\(tab\)[\s\S]*?youtubeTabId = tab\.id;[\s\S]*?playbackTrackingTick\(true\);/,
+    "same-video tab switches must re-bind and re-sync Follow playback without rebuilding",
+  );
+});
+
+test("saved video title and author fill in when page metadata is unavailable", () => {
+  const { chooseVideoMetadata } = loadSidepanelHelpers();
+
+  assert.equal(
+    chooseVideoMetadata("", "Cached video title"),
+    "Cached video title",
+  );
+  assert.equal(
+    chooseVideoMetadata(null, "Cached channel"),
+    "Cached channel",
+  );
+  assert.equal(
+    chooseVideoMetadata("Live video title", "Older cached title"),
+    "Live video title",
+  );
+});
+
+test("playback tracking keeps a relay fallback when a direct tab is unavailable", async () => {
+  const { getPlaybackState } = loadSidepanelHelpers({
+    sendMessage: () =>
+      Promise.resolve({ success: true, response: { currentTime: 42 } }),
+  });
+  const js = read("sidepanel.js");
+
+  assert.deepEqual(await getPlaybackState(), { currentTime: 42 });
+  assert.match(
+    js,
+    /chrome\.runtime\.sendMessage\(\{[\s\S]*?action: "relayToContent",[\s\S]*?tabId: youtubeTabId,[\s\S]*?payload,/,
+    "the relay fallback must keep targeting the selected YouTube tab",
+  );
+  assert.match(
+    read("background.js"),
+    /const targetTabId = Number\.isInteger\(message\.tabId\)[\s\S]*?chrome\.tabs\.get\(targetTabId\)[\s\S]*?tabs = targetTab\s*\? \[targetTab\]/,
+    "the selected YouTube tab must be preferred over a newly queried tab",
+  );
+});
+
+test("transcript entry lookup keeps fractional timestamps precise", () => {
+  const { findTranscriptEntryForTime } = loadSidepanelHelpers();
+  const entries = [
+    { dataset: { seconds: "10.25" } },
+    { dataset: { seconds: "12.75" } },
+    { dataset: { seconds: "15.5" } },
+  ];
+
+  assert.equal(findTranscriptEntryForTime(entries, 12.6), entries[0]);
+  assert.equal(findTranscriptEntryForTime(entries, 12.75), entries[1]);
+  assert.equal(findTranscriptEntryForTime(entries, 15.7), entries[2]);
+});
+
+test("Follow playback refreshes the current player position before scrolling", () => {
+  const js = read("sidepanel.js");
+
+  assert.match(
+    js,
+    /const didScroll = await playbackTrackingTick\(true\);[\s\S]*?if \(!didScroll\) scrollToActiveEntry\(\);/,
+    "the button must fall back to the existing highlight instead of looking dead",
+  );
+  assert.match(
+    js,
+    /async function playbackTrackingTick\(forceScroll = false\)[\s\S]*?return highlightActiveEntry\(currentTime, forceScroll\);/,
+  );
+  assert.match(
+    js,
+    /if \(forceScroll && autoScrollEnabled\) \{[\s\S]*?scrollTranscriptEntryIntoView\(activeEntry\);[\s\S]*?return true;/,
+  );
+  assert.match(
+    js,
+    /contentArea\.addEventListener\("scrollend", onContentAreaScrollEnd\)/,
+    "programmatic smooth scrolling must remain marked until it actually ends",
+  );
+  assert.match(
+    js,
+    /function onContentAreaScroll\(\) \{\s*if \(programmaticTranscriptScroll\) return;/,
+    "the extension's own scrolling must not turn Follow playback off",
+  );
+  assert.match(
+    js,
+    /function onManualTranscriptNavigation\(\)[\s\S]*?finishProgrammaticTranscriptScroll\(\);[\s\S]*?disableAutoScrollForManualNavigation\(\);/,
+    "real wheel and touch input must still pause following immediately",
+  );
+  assert.doesNotMatch(
+    js,
+    /lastAutoScrollTime/,
+    "a fixed time window cannot reliably classify a long smooth scroll",
+  );
+  assert.match(
+    js,
+    /autoScrollInterval = setInterval\(\(\) => playbackTrackingTick\(\), 500\);[\s\S]*?playbackTrackingTick\(true\);/,
+    "initial follow must force a jump to the current playback position",
+  );
+});
+
+test("programmatic transcript scrolling cannot be mistaken for manual scrolling", () => {
+  const {
+    beginProgrammaticTranscriptScroll,
+    finishProgrammaticTranscriptScroll,
+    getTranscriptScrollGuardState,
+    onManualTranscriptNavigation,
+  } = loadSidepanelHelpers();
+
+  beginProgrammaticTranscriptScroll();
+  assert.equal(getTranscriptScrollGuardState().programmatic, true);
+
+  finishProgrammaticTranscriptScroll();
+  assert.equal(getTranscriptScrollGuardState().programmatic, false);
+
+  beginProgrammaticTranscriptScroll();
+  onManualTranscriptNavigation();
+  assert.equal(
+    getTranscriptScrollGuardState().programmatic,
+    false,
+    "real user input must interrupt a smooth programmatic scroll",
+  );
+});
+
 test("semantic segmentation rebuilds sentences across caption boundaries", () => {
   const { groupTranscriptEntries } = loadSidepanelHelpers();
   const segments = groupTranscriptEntries(
@@ -255,6 +533,26 @@ test("structured translation batches align by stable ID and expose missing fallb
   assert.equal(aligned[0].text, "");
   assert.match(aligned[0].error, /unavailable/i);
   assert.equal(aligned[1].text, "\u7b2c\u4e8c\u4e2a\u5b8c\u6574\u53e5\u5b50\u3002");
+});
+
+test("transcript translation queues every missing row after the first viewport", () => {
+  const js = read("sidepanel.js");
+
+  assert.match(
+    js,
+    /const indices = queue\.splice\(0, 4\);/,
+    "batch size should use the full provider-supported transcript window",
+  );
+  assert.match(
+    js,
+    /if \(index < 4\) enqueue\(index\);/,
+    "the first visible rows should still translate immediately",
+  );
+  assert.match(
+    js,
+    /setTimeout\(\(\) => \{[\s\S]*?rows\.forEach\(\(row, index\) => \{[\s\S]*?!row\.classList\.contains\("translated"\)[\s\S]*?enqueue\(index\);/,
+    "remaining untranslated rows must be queued even if the user never scrolls to them",
+  );
 });
 
 test("translated-only omits English while bilingual renders aligned English and Chinese", () => {
@@ -593,4 +891,21 @@ test("Chinese prompt preserves natural bilingual-learning style rules", () => {
   assert.match(prompt, /Use 你, never 您/);
   assert.match(prompt, /spaces between Chinese and adjacent English words or digits/);
   assert.match(prompt, /source-language `text`/);
+});
+
+test("both transcript paths feed speaker-marker-cleaned text to the AI provider", () => {
+  const source = read("background.js");
+  const cleaned = (source.match(/\$\{cleanText\}\\n`/g) || []).length;
+  assert.equal(
+    cleaned,
+    2,
+    "the synchronous and async polling paths must both use cleaned text",
+  );
+  assert.doesNotMatch(source, /\$\{chunk\.text\}\\n/);
+});
+
+test("background service worker has no dead action.onClicked listener", () => {
+  const source = read("background.js");
+  assert.doesNotMatch(source, /chrome\.action\.onClicked\.addListener/);
+  assert.match(source, /openPanelOnActionClick: true/);
 });

--- a/tests/translation.test.js
+++ b/tests/translation.test.js
@@ -828,6 +828,38 @@ test("DeepSeek retries one empty transcript JSON response without response_forma
   assert.equal(requests[0].max_tokens, 1536);
 });
 
+test("selected text translation uses the plain text prompt path", async () => {
+  const requests = [];
+  const helpers = loadBackgroundHelpers({
+    fetchImpl: async (url, options) => {
+      if (url.startsWith("chrome-extension://")) {
+        return { ok: true, text: async () => read("prompts/translation.md") };
+      }
+      requests.push(JSON.parse(options.body));
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: "这是一段中文翻译。" } }],
+        }),
+      };
+    },
+  });
+
+  const result = await helpers.handleTranslateContent(
+    { text: "This is selected text." },
+    "selectedText",
+    "zh",
+    "Video",
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(result.translatedContent.text, "这是一段中文翻译。");
+  assert.equal(requests.length, 1);
+  assert.match(requests[0].messages[0].content, /selected transcript text/);
+  assert.equal(requests[0].messages[1].content, "This is selected text.");
+  assert.equal(Object.hasOwn(requests[0], "response_format"), false);
+});
+
 test("translation message watchdog rejects, clears its timer, and ignores late replies", async () => {
   let timeoutCallback;
   let timeoutDelay;


### PR DESCRIPTION
## Summary
Adds self-rendered bilingual subtitles on the video player and several transcript/playback enhancements.

## Changes
- Self-rendered bilingual captions on the player (Supadata transcript + DeepSeek translation), with semantic segmentation matching the side panel and a player-relative toggle button
- Follow-playback tracking plus original/Chinese/bilingual transcript modes in the side panel
- Fix speaker-marker (">>") leak in async transcript polling
- Ignore Cmd/Ctrl/Alt+N in the note keyboard shortcut
- Remove dead chrome.action.onClicked listener
- Scale captions and toggle spacing with player size

## Tests
- npm test: 61/61 passing
- npm run check: passing