### PR TITLE
feat: support hour-aware timestamps and reliable playback tracking

### DIFF
--- a/background.js
+++ b/background.js
@@ -892,18 +892,14 @@ async function handleAnalyzeTranscript(
       Math.floor(videoDuration || 0),
       lastTranscriptSeconds,
     );
-    const durationMinutes = Math.floor(effectiveSeconds / 60);
-    const durationSeconds = Math.floor(effectiveSeconds % 60);
-    const durationFormatted = `${durationMinutes}:${String(durationSeconds).padStart(2, "0")}`;
+    const durationFormatted = YTD_SETTINGS.formatTimestamp(effectiveSeconds);
     const maxTimestampSeconds = effectiveSeconds;
 
     // The "last chapter must be after" threshold (75% in) forces the model to
     // cover the WHOLE video instead of front-loading chapters near the start.
     // We do NOT prescribe a chapter count — the model picks the natural splits.
     const lateThresholdSeconds = Math.floor(effectiveSeconds * 0.75);
-    const lateThreshold = `${Math.floor(lateThresholdSeconds / 60)}:${String(
-      lateThresholdSeconds % 60,
-    ).padStart(2, "0")}`;
+    const lateThreshold = YTD_SETTINGS.formatTimestamp(lateThresholdSeconds);
 
     const promptVariables = {
       durationFormatted,
@@ -983,12 +979,7 @@ function validateAndFixTimestamps(analysis, maxSeconds) {
       ? Number(maxSeconds)
       : Number.MAX_SAFE_INTEGER;
 
-  // Helper to format seconds as MM:SS
-  const formatTimestamp = (seconds) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = Math.floor(seconds % 60);
-    return `${mins}:${String(secs).padStart(2, "0")}`;
-  };
+  const formatTimestamp = (seconds) => YTD_SETTINGS.formatTimestamp(seconds);
 
   const safeString = (value, maxLength) =>
     typeof value === "string" ? value.trim().slice(0, maxLength) : "";
@@ -1192,10 +1183,8 @@ async function handleSaveNote(
       videoTitle,
     );
 
-    // Format timestamp as MM:SS
-    const minutes = Math.floor(safeTimestamp / 60);
-    const seconds = safeTimestamp % 60;
-    const formattedTimestamp = `${minutes}:${String(seconds).padStart(2, "0")}`;
+    // Format timestamp for display
+    const formattedTimestamp = YTD_SETTINGS.formatTimestamp(safeTimestamp);
 
     // Create timestamped URL
     const timestampedUrl = `${canonicalVideoUrl}&t=${safeTimestamp}s`;

--- a/settings.js
+++ b/settings.js
@@ -54,6 +54,19 @@ var YTD_SETTINGS = (() => {
     return `https://www.youtube.com/watch?v=${normalized}`;
   }
 
+  // Human-facing timestamps use H:MM:SS once a video crosses one hour;
+  // model-facing [M:SS] transcript markers stay compact on purpose.
+  function formatTimestamp(seconds) {
+    const total = Math.max(0, Math.floor(Number(seconds) || 0));
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    const secs = total % 60;
+    if (hours > 0) {
+      return `${hours}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+    }
+    return `${minutes}:${String(secs).padStart(2, "0")}`;
+  }
+
   return {
     STORAGE_KEY,
     DEFAULTS,
@@ -62,6 +75,7 @@ var YTD_SETTINGS = (() => {
     migrateLegacyCustom,
     chatCompletionsUrl,
     canonicalYouTubeUrl,
+    formatTimestamp,
   };
 })();
 

--- a/sidepanel.css
+++ b/sidepanel.css
@@ -472,7 +472,7 @@ body {
   font-size: 11.5px;
   font-weight: 500;
   color: var(--accent);
-  min-width: 46px;
+  min-width: 52px;
   padding: 3px 8px;
   background: var(--accent-dim);
   border-radius: var(--r-sm);
@@ -637,7 +637,7 @@ body {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--accent);
-  min-width: 46px;
+  min-width: 52px;
   padding-top: 2px;
   flex-shrink: 0;
 }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -850,9 +850,7 @@ function renderTranscript() {
     div.className = "transcript-entry";
     div.dataset.seconds = group.start;
 
-    const minutes = Math.floor(group.start / 60);
-    const seconds = Math.floor(group.start % 60);
-    const timestamp = `${minutes}:${String(seconds).padStart(2, "0")}`;
+    const timestamp = YTD_SETTINGS.formatTimestamp(group.start);
 
     div.innerHTML = `
       <span class="transcript-time">${timestamp}</span>
@@ -1638,17 +1636,39 @@ function stopPlaybackTracking() {
 /**
  * One tick of the playback tracker. Gets current video time from the
  * YouTube tab and highlights + scrolls to the matching transcript entry.
+ * Tries the stored tab ID directly first; only falls back to the background
+ * relay when that tab is gone — the relay runs a multi-step tab search that
+ * is far too heavy to repeat twice a second.
  */
 async function playbackTrackingTick() {
   try {
-    const result = await chrome.runtime.sendMessage({
-      action: "relayToContent",
-      payload: { action: "getCurrentTime" },
-    });
+    let payload = null;
 
-    if (!result.success || !result.response) return;
+    if (youtubeTabId) {
+      try {
+        payload = await chrome.tabs.sendMessage(youtubeTabId, {
+          action: "getCurrentTime",
+        });
+      } catch (directErr) {
+        debugLog(
+          "[YouTube Digest Panel] Direct getCurrentTime failed, falling back to relay:",
+          directErr.message,
+        );
+      }
+    }
 
-    const currentTime = result.response.currentTime || 0;
+    if (!payload) {
+      const result = await chrome.runtime.sendMessage({
+        action: "relayToContent",
+        payload: { action: "getCurrentTime" },
+      });
+      if (!result?.success) return;
+      payload = result.response;
+    }
+
+    if (!payload) return;
+
+    const currentTime = payload.currentTime || 0;
     highlightActiveEntry(currentTime);
   } catch (error) {
     // Silently ignore — YouTube tab might be closed or navigated away
@@ -1827,9 +1847,7 @@ function renderTranscriptModeRows(segments, mode) {
     div.dataset.segmentId = segment.id;
     div.dataset.segmentIndex = index;
 
-    const minutes = Math.floor(segment.start / 60);
-    const seconds = Math.floor(segment.start % 60);
-    const timestamp = `${minutes}:${String(seconds).padStart(2, "0")}`;
+    const timestamp = YTD_SETTINGS.formatTimestamp(segment.start);
     div.innerHTML = `
       <span class="transcript-time">${timestamp}</span>
       ${renderTranscriptSegmentContent(segment, mode, cached, "")}


### PR DESCRIPTION
## Summary

- format timestamps as `H:MM:SS` once a video passes one hour while preserving `M:SS` for shorter videos
- use the shared timestamp formatter for chapters, notes, analysis prompts, and transcript rows
- poll playback time directly from the stored YouTube tab and keep the background relay as a fallback when that tab is unavailable
- reserve the transcript playback indicator border so active-row highlighting does not shift the layout

## Why

The existing minute-only formatting becomes ambiguous on long videos, and playback tracking can be less reliable when it depends only on the background relay. This keeps navigation accurate for long-form videos without changing the extension's provider, storage, or permission model.

## Scope

This PR is based directly on the current upstream `main` and changes only four runtime files. It does not include the other features from my fork.

## Validation

- `npm test` (42/42 passing)
- JavaScript syntax checks for `background.js`, `settings.js`, and `sidepanel.js`
- `git diff --check`
- provider-style credential scan

I noticed the README says upstream issues and pull requests are not accepted. I am opening this as a draft and will reach out separately before requesting review; if external contributions remain out of scope, please feel free to close it.